### PR TITLE
feat : 채팅 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 flowday_dev.mv.db
 flowday_dev.trace.db
 /src/main/resources/application-secret.yml
+/src/main/resources/static

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/example/flowday/FlowdayApplication.java
+++ b/src/main/java/org/example/flowday/FlowdayApplication.java
@@ -3,7 +3,9 @@ package org.example.flowday;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
 
+@EnableWebSocket
 @SpringBootApplication
 @EnableJpaAuditing
 public class FlowdayApplication {

--- a/src/main/java/org/example/flowday/domain/chat/common/ApiResponse.java
+++ b/src/main/java/org/example/flowday/domain/chat/common/ApiResponse.java
@@ -1,0 +1,33 @@
+package org.example.flowday.domain.chat.common;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String statusMessage;
+    private final T data;
+
+    public ApiResponse(
+            final String statusMessage,
+            final T data) {
+        this.statusMessage = statusMessage;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(final T data) {
+        return new ApiResponse<>(
+                "성공",
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> error(final T data) {
+        return new ApiResponse<>(
+                "실패",
+                data
+        );
+    }
+
+}
+

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
 
-@RequestMapping("/v1/chat")
+@RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
 @RestController
 public class ChatApiController {

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
@@ -1,0 +1,65 @@
+package org.example.flowday.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.chat.common.ApiResponse;
+import org.example.flowday.domain.chat.dto.ChatResponse;
+import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.service.ChatService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import java.time.LocalDateTime;
+
+@RequestMapping("/v1/chat")
+@RequiredArgsConstructor
+@Controller
+public class ChatApiController {
+    private final ChatService chatService;
+
+    /**
+     * 채팅 방 생성
+     * - 연인 수락을 하면 채팅방 id가 생성된다
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse> registerChatRoom() {
+        LocalDateTime time = LocalDateTime.now();
+        Long chatRoomId = chatService.registerChatRoom(time);
+        return ResponseEntity.ok(ApiResponse.success(chatRoomId));
+    }
+
+
+    /**
+     * 채팅 조회 (최신 10개, page)
+     */
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse> getPagedChatMessages(
+            @PathVariable Long roomId,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "sendTime"
+        ));
+        Page<ChatMessageEntity> messages = chatService.getPagedChatMessages(roomId, pageable);
+        Page<ChatResponse> chatResponses = messages.map(ChatResponse::from);
+        return ResponseEntity.ok(ApiResponse.success(chatResponses));
+    }
+
+    /**
+     * 채팅 방 삭제
+     */
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<ApiResponse> deleteChatRoom(@PathVariable Long roomId) {
+        Long deletedChatRoomId = chatService.deleteChatRoom(roomId);
+        return ResponseEntity.ok(ApiResponse.success(deletedChatRoomId));
+    }
+
+}

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
@@ -10,18 +10,18 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
 
 @RequestMapping("/v1/chat")
 @RequiredArgsConstructor
-@Controller
+@RestController
 public class ChatApiController {
     private final ChatService chatService;
 

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
@@ -1,0 +1,56 @@
+package org.example.flowday.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.chat.dto.ChatMessage;
+import org.example.flowday.domain.chat.dto.ChatResponse;
+import org.example.flowday.global.security.util.JwtUtil;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Controller
+public class ChatController {
+
+    private final JwtUtil jwtUtil;
+
+    @MessageMapping("/chat/{roomId}")
+    @SendTo("/topic/rooms/{roomId}")
+    public ChatResponse chatting(
+            @DestinationVariable Long roomId,
+            ChatMessage chatMessage
+    ) {
+        // TODO : 인증 처리
+        // @Header("Authorization") String bearerToken,
+//        String accessToken = resolveToken(bearerToken);
+//        Long senderId = getIdByValidating(accessToken);
+
+        LocalDateTime time = LocalDateTime.now();
+        // TODO : time을 포함한 채팅 로그 저장해야함 (동기, 비동기)
+
+        String responseMessage = HtmlUtils.htmlEscape(chatMessage.message());
+        return new ChatResponse(3L, responseMessage, time);
+    }
+
+    private Long getIdByValidating(String token) {
+        if (jwtUtil.isExpired(token)) {
+            throw new IllegalArgumentException("[ERROR] 이미 만료된 토큰입니다.");
+        }
+
+        Long id = jwtUtil.getId(token);
+        Objects.requireNonNull(id, "[ERROR] 인증 id가 존재하지 않습니다.");
+        return id;
+    }
+
+    private String resolveToken(String bearerToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
@@ -3,6 +3,7 @@ package org.example.flowday.domain.chat.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.flowday.domain.chat.dto.ChatMessage;
 import org.example.flowday.domain.chat.dto.ChatResponse;
+import org.example.flowday.domain.chat.service.ChatService;
 import org.example.flowday.global.security.util.JwtUtil;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -18,23 +19,29 @@ import java.util.Objects;
 public class ChatController {
 
     private final JwtUtil jwtUtil;
+    private final ChatService chatService;
 
+    /**
+     * 웹 소켓 연결
+     */
     @MessageMapping("/chat/{roomId}")
     @SendTo("/topic/rooms/{roomId}")
     public ChatResponse chatting(
             @DestinationVariable Long roomId,
             ChatMessage chatMessage
     ) {
-        // TODO : 인증 처리
-        // @Header("Authorization") String bearerToken,
+        // TODO : 인증
+//        @Header("Authorization") String bearerToken,
 //        String accessToken = resolveToken(bearerToken);
 //        Long senderId = getIdByValidating(accessToken);
 
         LocalDateTime time = LocalDateTime.now();
-        // TODO : time을 포함한 채팅 로그 저장해야함 (동기, 비동기)
-
         String responseMessage = HtmlUtils.htmlEscape(chatMessage.message());
-        return new ChatResponse(3L, responseMessage, time);
+
+        // TODO : 채팅 로그 저장 (동기 -> 비동기), senderId 넣어야함
+        chatService.saveMessage(roomId, 99L, responseMessage, time);
+
+        return new ChatResponse(99L, responseMessage, time);
     }
 
     private Long getIdByValidating(String token) {

--- a/src/main/java/org/example/flowday/domain/chat/controller/StompWebSocketEventHandler.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/StompWebSocketEventHandler.java
@@ -1,0 +1,41 @@
+package org.example.flowday.domain.chat.controller;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@Slf4j
+@Component
+public class StompWebSocketEventHandler {
+
+    @EventListener
+    public void handleWebSocketSessionConnectEvent(SessionConnectEvent event) {
+        log.info("세션(클라이언트)가 연결을 시도합니다...");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionConnectedEvent(SessionConnectedEvent event) {
+        log.info("세션(클라이언트)이 연결되었습니다. " + event.getMessage());
+    }
+
+    @EventListener
+    public void handleWebSocketSessionSubscribeEvent(SessionSubscribeEvent event) {
+        log.info("세션(클라이언트)이 토픽을 구독하였습니다.");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionUnsubscribeEvent(SessionUnsubscribeEvent event) {
+        log.info("세션(클라이언트)가 구독을 취소하였습니다.");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionDisconnectEvent(SessionDisconnectEvent event) {
+        log.info("세션(클라이언트) 연결이 종료되었습니다.");
+    }
+}

--- a/src/main/java/org/example/flowday/domain/chat/dto/ChatMessage.java
+++ b/src/main/java/org/example/flowday/domain/chat/dto/ChatMessage.java
@@ -1,0 +1,6 @@
+package org.example.flowday.domain.chat.dto;
+
+public record ChatMessage(
+        String message
+) {
+}

--- a/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
@@ -1,0 +1,10 @@
+package org.example.flowday.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatResponse(
+        Long senderId,
+        String message,
+        LocalDateTime time
+) {
+}

--- a/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
@@ -1,5 +1,6 @@
 package org.example.flowday.domain.chat.dto;
 
+import org.example.flowday.domain.chat.entity.ChatMessageEntity;
 import java.time.LocalDateTime;
 
 public record ChatResponse(
@@ -7,4 +8,11 @@ public record ChatResponse(
         String message,
         LocalDateTime time
 ) {
+    public static ChatResponse from(final ChatMessageEntity chatMessageEntity) {
+        return new ChatResponse(
+                chatMessageEntity.getFromId(),
+                chatMessageEntity.getTextMessage(),
+                chatMessageEntity.getSendTime()
+        );
+    }
 }

--- a/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageEntity.java
+++ b/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageEntity.java
@@ -1,0 +1,65 @@
+package org.example.flowday.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class ChatMessageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_message_no", nullable = false)
+    private Long id;
+
+    @Column(name = "chat_room_id", nullable = false)
+    private Long chatRoomId;
+
+    @Column
+    private Long fromId;
+
+    @Column(nullable = false)
+    private String textMessage;
+
+    @Column(nullable = false)
+    private LocalDateTime sendTime;
+
+    @Builder
+    public ChatMessageEntity(
+            final Long id,
+            final Long chatRoomId,
+            final Long fromId,
+            final String textMessage,
+            final LocalDateTime sendTime
+    ) {
+        this.id = id;
+        this.chatRoomId = chatRoomId;
+        this.fromId = fromId;
+        this.textMessage = textMessage;
+        this.sendTime = sendTime;
+    }
+
+    public static ChatMessageEntity create(
+            final Long chatRoomId,
+            final Long fromId,
+            final String textMessage,
+            final LocalDateTime sendTime
+    ) {
+        return ChatMessageEntity.builder()
+                .chatRoomId(chatRoomId)
+                .fromId(fromId)
+                .textMessage(textMessage)
+                .sendTime(sendTime)
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/flowday/domain/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/org/example/flowday/domain/chat/entity/ChatRoomEntity.java
@@ -1,0 +1,51 @@
+package org.example.flowday.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ChatRoomEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_no", nullable = false)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    protected LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @Builder
+    public ChatRoomEntity(
+            final Long id,
+            final LocalDateTime createdAt,
+            final LocalDateTime deletedAt
+    ) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public static ChatRoomEntity create(
+            final LocalDateTime createdAt
+    ) {
+        return ChatRoomEntity.builder()
+                .createdAt(createdAt)
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package org.example.flowday.domain.chat.repository;
+
+import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
+    Page<ChatMessageEntity> findByChatRoomId(Long roomId, Pageable pageable);
+
+}

--- a/src/main/java/org/example/flowday/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/flowday/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package org.example.flowday.domain.chat.repository;
+
+import org.example.flowday.domain.chat.entity.ChatRoomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+}

--- a/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
+++ b/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
@@ -1,0 +1,71 @@
+package org.example.flowday.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.entity.ChatRoomEntity;
+import org.example.flowday.domain.chat.repository.ChatMessageRepository;
+import org.example.flowday.domain.chat.repository.ChatRoomRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ChatService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+
+    /**
+     * 채팅 방 생성
+     */
+    public Long registerChatRoom(final LocalDateTime time) {
+        ChatRoomEntity chatRoom = ChatRoomEntity.create(
+                time
+        );
+        ChatRoomEntity savedChatRoom = chatRoomRepository.save(chatRoom);
+        Long chatRoomId = savedChatRoom.getId();
+        return chatRoomId;
+    }
+
+    /**
+     * 채팅 메세지 저장
+     */
+    public void saveMessage(
+            final Long roomId,
+            final Long senderId,
+            final String responseMessage,
+            final LocalDateTime time
+    ) {
+        ChatMessageEntity chatMessage = ChatMessageEntity.create(
+                roomId,
+                senderId,
+                responseMessage,
+                time
+        );
+        chatMessageRepository.save(chatMessage);
+    }
+
+    /**
+     * 채팅 조회
+     */
+    public Page<ChatMessageEntity> getPagedChatMessages(
+            final Long roomId,
+            final Pageable pageable
+    ) {
+        return chatMessageRepository.findByChatRoomId(roomId, pageable);
+    }
+
+    /**
+     * 채팅 방 삭제
+     */
+    public Long deleteChatRoom(final Long roomId) {
+        ChatRoomEntity chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
+
+        chatRoomRepository.delete(chatRoom);
+        return roomId;
+    }
+
+}

--- a/src/main/java/org/example/flowday/global/config/StompWebSocketConfig.java
+++ b/src/main/java/org/example/flowday/global/config/StompWebSocketConfig.java
@@ -1,0 +1,29 @@
+package org.example.flowday.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * 클라이언트가 서버에 소켓 연결할 때 경로 : /connect/websocket
+ * 클라이언트가 서버에 구독요청할 경로 : /topic/rooms/{roomId}
+ * 채팅 메세지 보낼 때 요청할 경로 : /chat/{roomId} + message body
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/connect/websocket")
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/org/example/flowday/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/flowday/global/security/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                         )
                         .permitAll()
                         .requestMatchers(
+                                "/connect/websocket",
                                 "/api/v1/members/login",
                                 "/api/v1/members",
                                 "/oauth2/**"


### PR DESCRIPTION
## 🔓closed #13 

## 📌 과제 설명 
- 채팅 기본 기능 구현

## 👩‍💻 요구 사항과 구현 내용 
- 웹 소켓 연결 
- 채팅 방 생성
- 채팅 메세지 조회 (최신순 10개 페이지로 조회)
- 채팅 방 삭제

## ✋ PR 포인트 & 궁금한 점
- 현재 클라이언트 구현 전이라 백엔드에서 간단하게 프론트 코드를 작성하여 웹소켓 연결 테스트를 진행 했습니다.