### PR TITLE
refactor : 코스 투표 재구현

### DIFF
--- a/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
+++ b/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
@@ -50,7 +50,7 @@ public class CourseController {
     // 코스 수정 - 장소 순서 변경
     @Operation(summary = "장소 순서 변경")
     @PatchMapping("/{courseId}/spot/{spotId}/sequence/{sequence}")
-    public ResponseEntity<Void> updateCourse(
+    public ResponseEntity<Void> updateSpotSequence(
             @PathVariable Long courseId,
             @PathVariable Long spotId,
             @PathVariable int sequence,
@@ -63,12 +63,13 @@ public class CourseController {
     // 코스에 장소 1개 추가
     @Operation(summary = "장소 1개 추가")
     @PostMapping("/{courseId}")
-    public ResponseEntity<CourseResDTO> addSpotToCourse(
+    public ResponseEntity<Void> addSpotToCourse(
             @PathVariable Long courseId,
             @RequestBody SpotReqDTO spotReqDTO,
             @AuthenticationPrincipal SecurityUser user
     ) {
-        return ResponseEntity.ok(courseService.addSpot(user.getId(), courseId, spotReqDTO));
+        courseService.addSpot(user.getId(), courseId, spotReqDTO);
+        return ResponseEntity.noContent().build();
     }
 
     // 코스의 장소 1개 삭제

--- a/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
+++ b/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
@@ -36,19 +36,32 @@ public class CourseController {
         return ResponseEntity.ok(courseService.findCourse(courseId));
     }
 
-    // 코스 수정
-    @Operation(summary = "수정", description = "파트너가 수정 시에도 요청 DTO에는 memberId는 작성자의 id")
+    // 코스 수정 - 정보
+    @Operation(summary = "코스 정보 수정", description = "수정된 값만 넘겨주면 됨")
     @PutMapping("/{courseId}")
     public ResponseEntity<CourseResDTO> updateCourse(
             @PathVariable Long courseId,
             @RequestBody CourseReqDTO courseReqDTO,
             @AuthenticationPrincipal SecurityUser user
     ) {
-        return ResponseEntity.ok(courseService.updateCourse(user.getId(), courseId, courseReqDTO));
+        return ResponseEntity.ok(courseService.updateCourseInfo(user.getId(), courseId, courseReqDTO));
+    }
+
+    // 코스 수정 - 장소 순서 변경
+    @Operation(summary = "장소 순서 변경")
+    @PatchMapping("/{courseId}/spot/{spotId}/sequence/{sequence}")
+    public ResponseEntity<Void> updateCourse(
+            @PathVariable Long courseId,
+            @PathVariable Long spotId,
+            @PathVariable int sequence,
+            @AuthenticationPrincipal SecurityUser user
+    ) {
+        courseService.updateCourseSpotSequence(user.getId(), courseId, spotId, sequence);
+        return ResponseEntity.noContent().build();
     }
 
     // 코스에 장소 1개 추가
-    @Operation(summary = "장소 1개 추가", description = "코스에 장소를 1개 추가 / sequence(순서)는 마지막으로 배정")
+    @Operation(summary = "장소 1개 추가")
     @PostMapping("/{courseId}")
     public ResponseEntity<CourseResDTO> addSpotToCourse(
             @PathVariable Long courseId,
@@ -56,6 +69,18 @@ public class CourseController {
             @AuthenticationPrincipal SecurityUser user
     ) {
         return ResponseEntity.ok(courseService.addSpot(user.getId(), courseId, spotReqDTO));
+    }
+
+    // 코스의 장소 1개 삭제
+    @Operation(summary = "장소 1개 삭제")
+    @DeleteMapping("/{course_id}/spot/{spot_id}")
+    public ResponseEntity<Void> deleteSpotFromCourse(
+            @PathVariable("course_id") Long courseId,
+            @PathVariable("spot_id") Long spotId,
+            @AuthenticationPrincipal SecurityUser user
+    ) {
+        courseService.removeSpot(user.getId(), courseId, spotId);
+        return ResponseEntity.noContent().build();
     }
 
     // 코스 삭제
@@ -69,8 +94,8 @@ public class CourseController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "위시 플레이스 + 코스 목록 조회", description = "나와 (파트너의) 위시플레이스와 나와 (파트너의 COUPLE 상태) 코스 목록")
     // 회원 별 위시 플레이스, 코스 목록 조회
+    @Operation(summary = "위시 플레이스 + 코스 목록 조회", description = "나와 (파트너의) 위시플레이스와 나와 (파트너의 COUPLE 상태) 코스 목록")
     @GetMapping("/member/{memberId}")
     public ResponseEntity<Page<Object>> CourseListByMember(
             @PathVariable("memberId") Long memberId,

--- a/src/main/java/org/example/flowday/domain/course/course/dto/CourseReqDTO.java
+++ b/src/main/java/org/example/flowday/domain/course/course/dto/CourseReqDTO.java
@@ -27,6 +27,4 @@ public class CourseReqDTO {
 
     @NotBlank(message = "Color cannot be blank")
     private String color;
-
-    private List<SpotReqDTO> spots;
 }

--- a/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
+++ b/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
@@ -156,7 +156,7 @@ public class CourseService {
     }
 
     // 코스에 장소 1개 추가
-    public CourseResDTO addSpot(Long userId, Long courseId, SpotReqDTO spotReqDTO) {
+    public void addSpot(Long userId, Long courseId, SpotReqDTO spotReqDTO) {
         Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
 
         if (!userId.equals(course.getMember().getId()) && !userId.equals(course.getMember().getPartnerId())) {
@@ -181,14 +181,6 @@ public class CourseService {
                     .build();
 
             spotRepository.save(spot);
-
-            List<Spot> updatedSpots = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId);
-            List<SpotResDTO> spotResDTOs = updatedSpots.stream()
-                    .map(SpotResDTO::new)
-                    .toList();
-
-            return new CourseResDTO(course, spotResDTOs);
-
         } catch (Exception e) {
             e.printStackTrace();
             throw SpotException.NOT_CREATED.get();
@@ -228,7 +220,7 @@ public class CourseService {
 
         } catch (Exception e) {
             e.printStackTrace();
-            throw SpotException.NOT_CREATED.get();
+            throw SpotException.NOT_DELETED.get();
         }
     }
 

--- a/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
+++ b/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
@@ -26,7 +26,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -50,28 +52,12 @@ public class CourseService {
                     .status(courseReqDTO.getStatus())
                     .date(courseReqDTO.getDate())
                     .color(courseReqDTO.getColor())
+                    .spots(null)
                     .build();
 
             courseRepository.save(course);
 
-            List<SpotResDTO> spotResDTOs = new ArrayList<>();
-
-            for (SpotReqDTO spotReqDTO : courseReqDTO.getSpots()) {
-                Spot spot = Spot.builder()
-                        .placeId(spotReqDTO.getPlaceId())
-                        .name(spotReqDTO.getName())
-                        .city(spotReqDTO.getCity())
-                        .comment(spotReqDTO.getComment())
-                        .sequence(spotReqDTO.getSequence())
-                        .course(course)
-                        .build();
-
-                spotRepository.save(spot);
-
-                spotResDTOs.add(new SpotResDTO(spot));
-            }
-
-            CourseResDTO courseResDTO = new CourseResDTO(course, spotResDTOs);
+            CourseResDTO courseResDTO = new CourseResDTO(course, null);
 
             return courseResDTO;
         } catch (Exception e) {
@@ -82,9 +68,9 @@ public class CourseService {
     // 코스 조회
     public CourseResDTO findCourse(Long courseId) {
         Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
-        List<Spot> spots = spotRepository.findAllByCourseIdAndVoteIsNull(courseId);
-        List<SpotResDTO> spotResDTOs = new ArrayList<>();
+        List<Spot> spots = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId);
 
+        List<SpotResDTO> spotResDTOs = new ArrayList<>();
         for (Spot spot : spots) {
             spotResDTOs.add(new SpotResDTO(spot));
         }
@@ -92,8 +78,8 @@ public class CourseService {
         return new CourseResDTO(course, spotResDTOs);
     }
 
-    // 코스 수정
-    public CourseResDTO updateCourse(Long userId, Long courseId, CourseReqDTO courseReqDTO) {
+    // 코스 수정 - 정보
+    public CourseResDTO updateCourseInfo(Long userId, Long courseId, CourseReqDTO courseReqDTO) {
         Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
 
         if (!userId.equals(course.getMember().getId()) && !userId.equals(course.getMember().getPartnerId())) {
@@ -101,60 +87,68 @@ public class CourseService {
         }
 
         try {
-            course.changeTitle(courseReqDTO.getTitle());
-            course.changeDate(courseReqDTO.getDate());
-            course.changeColor(courseReqDTO.getColor());
-            course.changeStatus(courseReqDTO.getStatus());
-
-            List<Spot> existingSpots = spotRepository.findAllByCourseIdAndVoteIsNull(courseId);
-            List<SpotReqDTO> updatedSpots = courseReqDTO.getSpots();
-            List<SpotResDTO> spotResDTOs = new ArrayList<>();
-
-            for (SpotReqDTO spotReqDTO : updatedSpots) {
-                if (spotReqDTO.getId() != null) {
-                    Spot spot = existingSpots.stream()
-                            .filter(s -> s.getId().equals(spotReqDTO.getId()))
-                            .findFirst()
-                            .orElseThrow(SpotException.NOT_FOUND::get);
-
-                    spot.changePlaceId(spotReqDTO.getPlaceId());
-                    spot.changeName(spotReqDTO.getName());
-                    spot.changeCity(spotReqDTO.getCity());
-                    spot.changeComment(spotReqDTO.getComment());
-                    spot.changeSequence(spotReqDTO.getSequence());
-
-                    spotResDTOs.add(new SpotResDTO(spot));
-
-                } else {
-                    Spot spot = Spot.builder()
-                            .placeId(spotReqDTO.getPlaceId())
-                            .name(spotReqDTO.getName())
-                            .city(spotReqDTO.getCity())
-                            .comment(spotReqDTO.getComment())
-                            .sequence(spotReqDTO.getSequence())
-                            .course(course)
-                            .build();
-                    spotRepository.save(spot);
-                    spotResDTOs.add(new SpotResDTO(spot));
-                }
+            if (courseReqDTO.getTitle() != null) {
+                course.changeTitle(courseReqDTO.getTitle());
+            }
+            if (courseReqDTO.getDate() != null) {
+                course.changeDate(courseReqDTO.getDate());
+            }
+            if (courseReqDTO.getColor() != null) {
+                course.changeColor(courseReqDTO.getColor());
+            }
+            if (courseReqDTO.getStatus() != null) {
+                course.changeStatus(courseReqDTO.getStatus());
             }
 
-            // 코스에서 삭제된 spot 처리
-            List<Long> updatedSpotIds = updatedSpots.stream()
-                    .map(SpotReqDTO::getId)
-                    .toList();
+            List<SpotResDTO> spotResDTOs = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId)
+                    .stream()
+                    .map(SpotResDTO::new)
+                    .collect(Collectors.toList());
 
-            for (Spot existingSpot : existingSpots) {
-                if (!updatedSpotIds.contains(existingSpot.getId())) {
-                    try {
-                        spotRepository.delete(existingSpot);
-                    } catch (Exception e) {
-                        throw SpotException.NOT_DELETED.get();
+            return new CourseResDTO(course, spotResDTOs);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw CourseException.NOT_UPDATED.get();
+        }
+    }
+
+    // 코스 수정 - 장소 순서 변경
+    public void updateCourseSpotSequence(Long userId, Long courseId, Long spotId, int sequence) {
+        Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
+
+        if (!userId.equals(course.getMember().getId()) && !userId.equals(course.getMember().getPartnerId())) {
+            throw CourseException.FORBIDDEN.get();
+        }
+
+        try {
+            List<Spot> spots = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId);
+
+            // spotId에 해당하는 Spot 찾기
+            Spot inpustSpot = spots.stream()
+                    .filter(spot -> spot.getId().equals(spotId))
+                    .findFirst()
+                    .orElseThrow(SpotException.NOT_FOUND::get);
+            int beforeSequence = inpustSpot.getSequence();
+
+            inpustSpot.changeSequence(sequence);
+
+            // 순서 재배치
+            for (Spot spot : spots) {
+                if (!spot.getId().equals(spotId)) {
+                    if (beforeSequence < sequence) {
+                        if (spot.getSequence() > beforeSequence && spot.getSequence() <= sequence) {
+                            spot.changeSequence(spot.getSequence() - 1);
+                        }
+                    } else {
+                        if (spot.getSequence() < beforeSequence && spot.getSequence() >= sequence) {
+                            spot.changeSequence(spot.getSequence() + 1);
+                        }
                     }
                 }
             }
 
-            return new CourseResDTO(course, spotResDTOs);
+            spotRepository.saveAll(spots);
+
         } catch (Exception e) {
             e.printStackTrace();
             throw CourseException.NOT_UPDATED.get();
@@ -170,10 +164,11 @@ public class CourseService {
         }
 
         try {
-            List<Integer> existingSequences = spotRepository.findAllByCourseIdAndVoteIsNull(courseId).stream()
+            List<Integer> existingSequences = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId).stream()
                     .map(Spot::getSequence)
                     .toList();
 
+            // 가장 마지막 순서 배정
             int sequence = existingSequences.isEmpty() ? 1 : existingSequences.stream().max(Integer::compareTo).orElse(0) + 1;
 
             Spot spot = Spot.builder()
@@ -187,12 +182,49 @@ public class CourseService {
 
             spotRepository.save(spot);
 
-            List<Spot> updatedSpots = spotRepository.findAllByCourseIdAndVoteIsNull(courseId);
+            List<Spot> updatedSpots = spotRepository.findAllByCourseIdOrderBySequenceAsc(courseId);
             List<SpotResDTO> spotResDTOs = updatedSpots.stream()
                     .map(SpotResDTO::new)
                     .toList();
 
             return new CourseResDTO(course, spotResDTOs);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw SpotException.NOT_CREATED.get();
+        }
+    }
+
+    // 코스의 장소 1개 삭제
+    public void removeSpot(Long userId, Long courseId, Long spotId) {
+        Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
+
+        if (!userId.equals(course.getMember().getId()) && !userId.equals(course.getMember().getPartnerId())) {
+            throw CourseException.FORBIDDEN.get();
+        }
+
+        try {
+            Spot spotToRemove = course.getSpots().stream()
+                    .filter(spot -> spot.getId().equals(spotId))
+                    .findFirst()
+                    .orElseThrow(SpotException.NOT_FOUND::get);
+
+            course.getSpots().remove(spotToRemove);
+
+            spotRepository.delete(spotToRemove);
+
+            // 남은 장소 순서 재배치
+            List<Spot> updatedSpots = course.getSpots().stream()
+                    .sorted(Comparator.comparingInt(Spot::getSequence))
+                    .toList();
+
+            for (int i = 0; i < updatedSpots.size(); i++) {
+                Spot spot = updatedSpots.get(i);
+
+                spot.changeSequence(i + 1);
+
+                spotRepository.save(spot);
+            }
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -230,7 +262,7 @@ public class CourseService {
         List<CourseResDTO> courseResDTOs = combinedCourses.stream()
                 .sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()))
                 .map(course -> {
-                    List<Spot> spots = spotRepository.findAllByCourseIdAndVoteIsNull(course.getId());
+                    List<Spot> spots = spotRepository.findAllByCourseIdOrderBySequenceAsc(course.getId());
                     List<SpotResDTO> spotResDTOs = spots.stream()
                             .map(SpotResDTO::new)
                             .toList();

--- a/src/main/java/org/example/flowday/domain/course/spot/controller/SpotController.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/controller/SpotController.java
@@ -3,13 +3,11 @@ package org.example.flowday.domain.course.spot.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.course.spot.dto.SpotResDTO;
 import org.example.flowday.domain.course.spot.service.SpotService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,6 +25,13 @@ public class SpotController {
     public ResponseEntity<List<SpotResDTO>> getTopSpotsByCity(@RequestParam String city) {
         List<SpotResDTO> topSpots = spotService.getTopSpotsByCity(city);
         return ResponseEntity.ok(topSpots);
+    }
+
+    // commenet 수정
+    @Operation(summary = "commenet 수정")
+    @PatchMapping("/{spot_id}")
+    public ResponseEntity<SpotResDTO> updateComment(@PathVariable("spot_id") Long spotId, @RequestBody SpotReqDTO spotReqDTO) {
+        return ResponseEntity.ok(spotService.updateComment(spotId, spotReqDTO));
     }
 
 }

--- a/src/main/java/org/example/flowday/domain/course/spot/dto/SpotReqDTO.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/dto/SpotReqDTO.java
@@ -19,5 +19,4 @@ public class SpotReqDTO {
     private String city;
 
     private String comment;
-    private int sequence;
 }

--- a/src/main/java/org/example/flowday/domain/course/spot/entity/Spot.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/entity/Spot.java
@@ -34,18 +34,6 @@ public class Spot {
     @JoinColumn(name = "wish_place_id", nullable = true)
     private WishPlace wishPlace;
 
-    public void changePlaceId(String placeId) {
-        this.placeId = placeId;
-    }
-
-    public void changeName(String name) {
-        this.name = name;
-    }
-
-    public void changeCity(String city) {
-        this.city = city;
-    }
-
     public void changeComment(String comment) {
         this.comment = comment;
     }
@@ -54,8 +42,13 @@ public class Spot {
         this.sequence = sequence;
     }
 
+    public void changeVote(Vote vote) {
+        this.vote = vote;
+    }
+
     public void removeVote() {
         this.vote = null;
     }
+
 }
 

--- a/src/main/java/org/example/flowday/domain/course/spot/exception/SpotException.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/exception/SpotException.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum SpotException {
     NOT_FOUND("장소를 찾을 수 없습니다.",  HttpStatus.NOT_FOUND),
     NOT_DELETED("장소를 삭제하는 데 실패했습니다.", HttpStatus.BAD_REQUEST),
-    NOT_CREATED("장소를 생성하는 데 실패했습니다.", HttpStatus.BAD_REQUEST);
+    NOT_CREATED("장소를 생성하는 데 실패했습니다.", HttpStatus.BAD_REQUEST),
+    NOT_UPDATED("장소를 수정하는 데 실패했습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/org/example/flowday/domain/course/spot/repository/SpotRepository.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/repository/SpotRepository.java
@@ -10,5 +10,5 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     List<Spot> findAllByCourseIdOrderBySequenceAsc(Long courseId);
     List<Spot> findAllByVoteIdOrderBySequenceAsc(Long voteId);
     List<Spot> findAllByCity(String city);
-    List<Spot> findAllByWishPlaceId(Long wishPlaceId);
+    List<Spot> findAllByWishPlaceIdOrderByIdDesc(Long wishPlaceId);
 }

--- a/src/main/java/org/example/flowday/domain/course/spot/repository/SpotRepository.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/repository/SpotRepository.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public interface SpotRepository extends JpaRepository<Spot, Long> {
 
-    List<Spot> findAllByCourseIdAndVoteIsNull(Long courseId);
-    List<Spot> findAllByVoteId(Long voteId);
+    List<Spot> findAllByCourseIdOrderBySequenceAsc(Long courseId);
+    List<Spot> findAllByVoteIdOrderBySequenceAsc(Long voteId);
     List<Spot> findAllByCity(String city);
     List<Spot> findAllByWishPlaceId(Long wishPlaceId);
 }

--- a/src/main/java/org/example/flowday/domain/course/spot/service/SpotService.java
+++ b/src/main/java/org/example/flowday/domain/course/spot/service/SpotService.java
@@ -1,8 +1,10 @@
 package org.example.flowday.domain.course.spot.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.course.spot.dto.SpotResDTO;
 import org.example.flowday.domain.course.spot.entity.Spot;
+import org.example.flowday.domain.course.spot.exception.SpotException;
 import org.example.flowday.domain.course.spot.repository.SpotRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +44,19 @@ public class SpotService {
         return topSpotsList.stream()
                 .map(spot -> new SpotResDTO(spot))
                 .collect(Collectors.toList());
+    }
+
+    // comment 수정
+    public SpotResDTO updateComment(Long spotId, SpotReqDTO spotReqDTO) {
+        Spot spot = spotRepository.findById(spotId).orElseThrow(SpotException.NOT_FOUND::get);
+        try {
+            spot.changeComment(spotReqDTO.getComment());
+
+            return new SpotResDTO(spot);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw SpotException.NOT_UPDATED.get();
+        }
     }
 
 }

--- a/src/main/java/org/example/flowday/domain/course/vote/controller/VoteController.java
+++ b/src/main/java/org/example/flowday/domain/course/vote/controller/VoteController.java
@@ -21,7 +21,7 @@ public class VoteController {
     private final VoteService voteService;
 
     // 투표 생성
-    @Operation(summary = "생성", description = "알림 도메인 완성 시 변경 예정")
+    @Operation(summary = "생성")
     @PostMapping
     public ResponseEntity<VoteResDTO> createVote(
             @RequestBody VoteReqDTO voteReqDTO,
@@ -38,8 +38,8 @@ public class VoteController {
     }
 
     // 투표 완료 후 코스 수정
-    @Operation(summary = "투표 후 코스 수정", description = "파트너가 투표한 장소를 코스에 추가")
-    @PutMapping("/{voteId}/spot/{spotId}")
+    @Operation(summary = "투표 후 코스 수정", description = "파트너가 투표한 장소를 코스에 추가, 나머지 후보 삭제")
+    @PatchMapping("/{voteId}/spot/{spotId}")
     public ResponseEntity<CourseResDTO> updateCourseByVote(@PathVariable Long voteId, @PathVariable Long spotId) {
         return ResponseEntity.ok(voteService.updateCourseByVote(voteId, spotId));
     }

--- a/src/main/java/org/example/flowday/domain/course/vote/dto/VoteReqDTO.java
+++ b/src/main/java/org/example/flowday/domain/course/vote/dto/VoteReqDTO.java
@@ -16,6 +16,7 @@ public class VoteReqDTO {
     @NotBlank(message = "Title cannot be blank")
     private String title;
 
-    private List<SpotReqDTO> spots;
+    @NotNull(message = "Spot IDs cannot be null")
+    private List<Long> spotIds;
 }
 

--- a/src/main/java/org/example/flowday/domain/course/wish/controller/WishPlaceController.java
+++ b/src/main/java/org/example/flowday/domain/course/wish/controller/WishPlaceController.java
@@ -26,12 +26,12 @@ public class WishPlaceController {
     // 위시 플레이스에 장소 추가
     @Operation(summary = "장소 추가")
     @PostMapping
-    public ResponseEntity<WishPlaceResDTO> addSpotToWishPlace(
+    public ResponseEntity<Void> addSpotToWishPlace(
             @RequestBody WishPlaceReqDTO wishPlaceReqDTO,
             @AuthenticationPrincipal SecurityUser user
     ) {
-        WishPlaceResDTO updatedWishPlace = wishPlaceService.updateSpotInWishPlace(user.getId(), wishPlaceReqDTO);
-        return ResponseEntity.ok(updatedWishPlace);
+        wishPlaceService.updateSpotInWishPlace(user.getId(), wishPlaceReqDTO);
+        return ResponseEntity.noContent().build();
     }
 
     // 위시 플레이스에서 장소 삭제

--- a/src/main/java/org/example/flowday/domain/course/wish/service/WishPlaceService.java
+++ b/src/main/java/org/example/flowday/domain/course/wish/service/WishPlaceService.java
@@ -42,7 +42,7 @@ public class WishPlaceService {
     }
 
     // 위시 플레이스 장소 추가
-    public WishPlaceResDTO updateSpotInWishPlace(Long userId, WishPlaceReqDTO wishPlaceReqDTO) {
+    public void updateSpotInWishPlace(Long userId, WishPlaceReqDTO wishPlaceReqDTO) {
         if(!userId.equals(wishPlaceReqDTO.getMemberId())) {
             throw WishPlaceException.FORBIDDEN.get();
         }
@@ -59,13 +59,6 @@ public class WishPlaceService {
                     .build();
 
             spotRepository.save(newSpot);
-            wishPlace.getSpots().add(newSpot);
-
-            List<SpotResDTO> spotResDTOs = wishPlace.getSpots().stream()
-                    .map(spot -> new SpotResDTO(spot))
-                    .collect(Collectors.toList());
-
-            return new WishPlaceResDTO(wishPlace, spotResDTOs);
         } catch (Exception e) {
             e.printStackTrace();
             throw WishPlaceException.NOT_UPDATED.get();
@@ -101,7 +94,7 @@ public class WishPlaceService {
 
         return wishPlaces.stream()
                 .map(wishPlace -> {
-                    List<SpotResDTO> spotResDTOs = spotRepository.findAllByWishPlaceId(wishPlace.getId()).stream()
+                    List<SpotResDTO> spotResDTOs = spotRepository.findAllByWishPlaceIdOrderByIdDesc(wishPlace.getId()).stream()
                             .map(SpotResDTO::new)
                             .collect(Collectors.toList());
 
@@ -123,7 +116,7 @@ public class WishPlaceService {
 
         return wishPlaces.stream()
                 .map(wishPlace -> {
-                    List<SpotResDTO> spotResDTOs = spotRepository.findAllByWishPlaceId(wishPlace.getId()).stream()
+                    List<SpotResDTO> spotResDTOs = spotRepository.findAllByWishPlaceIdOrderByIdDesc(wishPlace.getId()).stream()
                             .map(SpotResDTO::new)
                             .collect(Collectors.toList());
 

--- a/src/main/java/org/example/flowday/domain/course/wish/service/WishPlaceService.java
+++ b/src/main/java/org/example/flowday/domain/course/wish/service/WishPlaceService.java
@@ -77,15 +77,21 @@ public class WishPlaceService {
         if(!userId.equals(memberId)) {
             throw WishPlaceException.FORBIDDEN.get();
         }
-        WishPlace wishPlace = wishPlaceRepository.findByMemberId(memberId).orElseThrow(WishPlaceException.NOT_FOUND::get);
 
-        Spot spotToRemove = wishPlace.getSpots().stream()
-                .filter(spot -> spot.getId().equals(spotId))
-                .findFirst()
-                .orElse(null);
+        try {
+            WishPlace wishPlace = wishPlaceRepository.findByMemberId(memberId).orElseThrow(WishPlaceException.NOT_FOUND::get);
 
-        wishPlace.getSpots().remove(spotToRemove);
-        spotRepository.delete(spotToRemove);
+            Spot spotToRemove = wishPlace.getSpots().stream()
+                    .filter(spot -> spot.getId().equals(spotId))
+                    .findFirst()
+                    .orElse(null);
+
+            wishPlace.getSpots().remove(spotToRemove);
+            spotRepository.delete(spotToRemove);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw WishPlaceException.NOT_DELETED.get();
+        }
     }
 
     // 회원 별 위시 플레이스 목록 조회

--- a/src/main/java/org/example/flowday/global/initData/NotProd.java
+++ b/src/main/java/org/example/flowday/global/initData/NotProd.java
@@ -129,7 +129,6 @@ public class NotProd {
                 .date(LocalDate.now())
                 .status(Status.COUPLE)
                 .memberId(member.getId())
-                .spots(spots)
                 .build();
 
         CourseResDTO courseResDTO = courseService.saveCourse(courseRequest);

--- a/src/main/java/org/example/flowday/global/initData/NotProd.java
+++ b/src/main/java/org/example/flowday/global/initData/NotProd.java
@@ -104,21 +104,18 @@ public class NotProd {
                 .placeId("place1")
                 .name("카페")
                 .comment("코멘트")
-                .sequence(1)
                 .build();
         SpotReqDTO spot2 = SpotReqDTO.builder()
                 .city("서울 종로")
                 .placeId("place2")
                 .name("밥집")
                 .comment("코멘트")
-                .sequence(2)
                 .build();
         SpotReqDTO spot3 = SpotReqDTO.builder()
                 .city("서울 종로")
                 .placeId("place3")
                 .name("영화관")
                 .comment("코멘트")
-                .sequence(3)
                 .build();
 
         List<SpotReqDTO> spots = new ArrayList<>();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 server:
-  port: 5000
+  port: 8090
 spring:
   thymeleaf:
     cache: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@ server:
   port: 5000
 spring:
   thymeleaf:
-    cache: false
+    cache: true
   output:
     ansi:
-      enabled: always
+      enabled: never

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,1 +1,8 @@
-
+server:
+  port: 5000
+spring:
+  thymeleaf:
+    cache: false
+  output:
+    ansi:
+      enabled: always

--- a/src/test/java/org/example/flowday/domain/course/course/controller/CourseControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/course/controller/CourseControllerTest.java
@@ -8,6 +8,7 @@ import org.example.flowday.domain.course.course.entity.Status;
 import org.example.flowday.domain.course.course.service.CourseService;
 import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.member.entity.Member;
+import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +21,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -47,8 +46,11 @@ class CourseControllerTest {
     private ObjectMapper objectMapper;
 
     private Member member;
+    private Member partner;
     private CourseReqDTO courseReqDTO;
     private CourseResDTO courseResDTO;
+    private CourseReqDTO courseReqDTO2;
+    private CourseResDTO courseResDTO2;
 
     @BeforeAll
     void setUp() {
@@ -56,9 +58,20 @@ class CourseControllerTest {
                 .name("tester")
                 .loginId("testId")
                 .pw("password")
+                .role(Role.ROLE_USER)
                 .build();
 
         memberRepository.save(member);
+
+        partner = Member.builder()
+                .name("partner")
+                .loginId("testId2")
+                .pw("password")
+                .role(Role.ROLE_USER)
+                .partnerId(member.getId())
+                .build();
+
+        memberRepository.save(partner);
 
         courseReqDTO = CourseReqDTO.builder()
                 .memberId(member.getId())
@@ -66,18 +79,39 @@ class CourseControllerTest {
                 .status(Status.COUPLE)
                 .date(LocalDate.now())
                 .color("blue")
-                .spots(Collections.singletonList(
-                        SpotReqDTO.builder()
-                                .id(1L)
-                                .placeId("ChIJgUbEo1")
-                                .name("장소 이름1")
-                                .city("서울")
-                                .sequence(1)
-                                .build()
-                ))
                 .build();
 
         courseResDTO = courseService.saveCourse(courseReqDTO);
+
+        SpotReqDTO spotReqDTO1 = SpotReqDTO.builder()
+                .id(1L)
+                .placeId("ChIJgUbEo3")
+                .name("성심당")
+                .city("대전")
+                .build();
+
+        courseService.addSpot(member.getId(), courseResDTO.getId(), spotReqDTO1);
+        courseResDTO = courseService.findCourse(courseResDTO.getId());
+
+        SpotReqDTO spotReqDTO2 = SpotReqDTO.builder()
+                .id(2L)
+                .placeId("ChIJgUbEo5")
+                .name("바다")
+                .city("울산")
+                .build();
+
+        courseService.addSpot(member.getId(), courseResDTO.getId(), spotReqDTO2);
+        courseResDTO = courseService.findCourse(courseResDTO.getId());
+
+        courseReqDTO2 = CourseReqDTO.builder()
+                .memberId(partner.getId())
+                .title("코스 이름")
+                .status(Status.COUPLE)
+                .date(LocalDate.now())
+                .color("blue")
+                .build();
+
+        courseResDTO2 = courseService.saveCourse(courseReqDTO2);
     }
 
     @DisplayName("코스 생성 테스트")
@@ -90,15 +124,6 @@ class CourseControllerTest {
                 .status(Status.COUPLE)
                 .date(LocalDate.now())
                 .color("blue")
-                .spots(Collections.singletonList(
-                        SpotReqDTO.builder()
-                                .id(1L)
-                                .placeId("ChIJgUbEo1")
-                                .name("장소 이름1")
-                                .city("서울")
-                                .sequence(1)
-                                .build()
-                ))
                 .build();
 
         mockMvc.perform(post("/api/v1/courses")
@@ -131,21 +156,6 @@ class CourseControllerTest {
                 .status(Status.PRIVATE)
                 .date(LocalDate.now())
                 .color("pink")
-                .spots(List.of(
-                        SpotReqDTO.builder()
-                                .id(1L)
-                                .placeId("ChIJgUbEo1")
-                                .name("장소 이름 수정")
-                                .city("서울")
-                                .sequence(1)
-                                .build(),
-                        SpotReqDTO.builder()
-                                .placeId("dkjdkfsj2")
-                                .name("장소 이름2")
-                                .city("대전")
-                                .sequence(2)
-                                .build()
-                ))
                 .build();
 
         mockMvc.perform(put("/api/v1/courses/{courseId}", courseResDTO.getId())
@@ -155,9 +165,22 @@ class CourseControllerTest {
                 .andDo(print())
                 .andExpect(jsonPath("$.title").value("코스 이름 수정"))
                 .andExpect(jsonPath("$.status").value("PRIVATE"))
-                .andExpect(jsonPath("$.color").value("pink"))
-                .andExpect(jsonPath("$.spots[0].name").value("장소 이름 수정"))
-                .andExpect(jsonPath("$.spots[1].name").value("장소 이름2"));
+                .andExpect(jsonPath("$.color").value("pink"));
+    }
+
+    @DisplayName("장소 순서 변경 테스트")
+    @Test
+    @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
+    void updateSpotSequence() throws Exception {
+        System.out.println("xxx");
+        System.out.println(courseResDTO.getSpots().size());
+        Long spotId = courseResDTO.getSpots().get(0).getId();
+        int newSequence = 2;
+
+        mockMvc.perform(patch("/api/v1/courses/{courseId}/spot/{spotId}/sequence/{sequence}",
+                        courseResDTO.getId(), spotId, newSequence)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
     }
 
     @DisplayName("코스에 장소 1개 추가 테스트")
@@ -173,11 +196,15 @@ class CourseControllerTest {
         mockMvc.perform(post("/api/v1/courses/{courseId}", courseResDTO.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(spotReqDTO)))
-                .andExpect(status().isOk())
-                .andDo(print())
-                .andExpect(jsonPath("$.title").value("코스 이름"))
-                .andExpect(jsonPath("$.spots[1].name").value("성심당"))
-                .andExpect(jsonPath("$.spots[1].sequence").value(2));
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("코스의 장소 1개 삭제 테스트")
+    @Test
+    @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
+    void deleteSpotFromCourse() throws Exception {
+        mockMvc.perform(delete("/api/v1/courses/{courseId}/spot/{spotId}", courseResDTO.getId(), courseResDTO.getSpots().get(0).getId()))
+                .andExpect(status().isNoContent());
     }
 
     @DisplayName("코스 삭제 테스트")
@@ -188,7 +215,7 @@ class CourseControllerTest {
                 .andExpect(status().isNoContent());
     }
 
-    @DisplayName("회원 별 위시 플레이스 및 코스 목록 조회 테스트 테스트")
+    @DisplayName("회원 별 위시 플레이스 및 코스 목록 조회 테스트")
     @Test
     @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
     void getCourseListByMember() throws Exception {
@@ -197,6 +224,20 @@ class CourseControllerTest {
         mockMvc.perform(get("/api/v1/courses/member/{memberId}", member.getId())
                         .param("page", "1")
                         .param("size", "10"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("비공개로 상태 변경 테스트")
+    @Test
+    @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
+    void updateCourseStatusToPrivate() throws Exception {
+        System.out.println("zzz");
+        System.out.println(member.getId());
+        System.out.println(member.getPartnerId());
+        System.out.println(partner.getId());
+        System.out.println(courseResDTO2.getMemberId());
+        mockMvc.perform(patch("/api/v1/courses/{courseId}/private", courseResDTO2.getId())
+                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/org/example/flowday/domain/course/spot/service/SpotServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/course/spot/service/SpotServiceTest.java
@@ -1,5 +1,6 @@
 package org.example.flowday.domain.course.spot.service;
 
+import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.course.spot.dto.SpotResDTO;
 import org.example.flowday.domain.course.spot.entity.Spot;
 import org.example.flowday.domain.course.spot.repository.SpotRepository;
@@ -11,8 +12,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 class SpotServiceTest {
@@ -38,6 +41,7 @@ class SpotServiceTest {
                 .placeId("ChIJgUbEo1")
                 .name("장소1")
                 .city("서울")
+                .comment("여기 빵 맛집이래")
                 .sequence(1)
                 .build();
 
@@ -101,6 +105,24 @@ class SpotServiceTest {
         assertThat(result).isEmpty();
 
         verify(spotRepository, times(1)).findAllByCity("부산");
+    }
+
+    @DisplayName("comment 수정 테스트")
+    @Test
+    void updateComment() {
+        when(spotRepository.findById(1L)).thenReturn(Optional.of(spot1));
+
+        SpotReqDTO spotReqDTO = SpotReqDTO.builder()
+                .comment("수정")
+                .build();
+
+        SpotResDTO spotResDTO = spotService.updateComment(spot1.getId(), spotReqDTO);
+
+        List<SpotResDTO> result = spotService.getTopSpotsByCity("서울");
+
+        assertEquals("수정", spotReqDTO.getComment());
+
+        verify(spotRepository, times(1)).findById(1L);
     }
 
 }

--- a/src/test/java/org/example/flowday/domain/course/vote/controller/VoteControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/vote/controller/VoteControllerTest.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.flowday.domain.course.course.entity.Course;
 import org.example.flowday.domain.course.course.entity.Status;
 import org.example.flowday.domain.course.course.repository.CourseRepository;
-import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.course.spot.entity.Spot;
 import org.example.flowday.domain.course.vote.dto.VoteReqDTO;
 import org.example.flowday.domain.course.vote.dto.VoteResDTO;
 import org.example.flowday.domain.course.vote.service.VoteService;
 import org.example.flowday.domain.member.entity.Member;
+import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +52,8 @@ class VoteControllerTest {
 
     private Member member;
     private Course course;
+    private Spot spot1;
+    private Spot spot2;
     private VoteReqDTO voteReqDTO;
     private VoteResDTO voteResDTO;
 
@@ -61,6 +63,7 @@ class VoteControllerTest {
                 .name("tester")
                 .loginId("testId")
                 .pw("password")
+                .role(Role.ROLE_USER)
                 .build();
 
         memberRepository.save(member);
@@ -83,25 +86,24 @@ class VoteControllerTest {
 
         courseRepository.save(course);
 
+        spot1 = Spot.builder()
+                .id(1L)
+                .placeId("ChIJgUbEo1")
+                .name("장소 이름1")
+                .city("서울")
+                .build();
+
+        spot2 = Spot.builder()
+                .id(2L)
+                .placeId("ChIJgUbEo1")
+                .name("장소 이름2")
+                .city("대전")
+                .build();
+
         voteReqDTO = VoteReqDTO.builder()
                 .courseId(course.getId())
                 .title("뭐먹지")
-                .spots(List.of(
-                        SpotReqDTO.builder()
-                                .id(1L)
-                                .placeId("ChIJgUbEo1")
-                                .name("장소 이름1")
-                                .city("서울")
-                                .sequence(1)
-                                .build(),
-                        SpotReqDTO.builder()
-                                .id(2L)
-                                .placeId("ChIJgUbEo1")
-                                .name("장소 이름2")
-                                .city("대전")
-                                .sequence(2)
-                                .build()
-                ))
+                .spotIds(List.of(spot1.getId(), spot2.getId()))
                 .build();
 
         voteResDTO = voteService.saveVote(member.getId(), voteReqDTO);
@@ -132,7 +134,7 @@ class VoteControllerTest {
     @Test
     @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
     void updateCourseByVote() throws Exception {
-        mockMvc.perform(put("/api/v1/votes/{voteId}/spot/{spotId}", voteResDTO.getId(), voteResDTO.getSpots().get(1).getId()))
+        mockMvc.perform(patch("/api/v1/votes/{voteId}/spot/{spotId}", voteResDTO.getId(), spot1.getId()))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/org/example/flowday/domain/course/vote/service/VoteServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/course/vote/service/VoteServiceTest.java
@@ -95,9 +95,7 @@ class VoteServiceTest {
         VoteReqDTO voteReqDTO = VoteReqDTO.builder()
                 .courseId(1L)
                 .title("뭐먹지")
-                .spots(List.of(
-                        SpotReqDTO.builder().id(1L).placeId("ChIJgUbEo1").name("장소 이름1").city("서울").sequence(1).build()
-                ))
+                .spotIds(List.of(spot.getId()))
                 .build();
 
         when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
@@ -110,21 +108,20 @@ class VoteServiceTest {
         assertEquals("뭐먹지", result.getTitle());
         verify(courseRepository).findById(1L);
         verify(voteRepository).save(any(Vote.class));
-        verify(spotRepository, times(1)).save(any(Spot.class));
     }
 
     @DisplayName("투표 조회 테스트")
     @Test
     void findVote() {
         when(voteRepository.findById(1L)).thenReturn(Optional.of(vote));
-        when(spotRepository.findAllByVoteId(1L)).thenReturn(List.of(spot));
+        when(spotRepository.findAllByVoteIdOrderBySequenceAsc(1L)).thenReturn(List.of(spot));
 
         VoteResDTO result = voteService.findVote(1L);
 
         assertNotNull(result);
         assertEquals("뭐먹지", result.getTitle());
         verify(voteRepository).findById(1L);
-        verify(spotRepository).findAllByVoteId(1L);
+        verify(spotRepository).findAllByVoteIdOrderBySequenceAsc(1L);
     }
     @DisplayName("투표 완료 후 코스 수정 테스트")
     @Test
@@ -134,7 +131,7 @@ class VoteServiceTest {
 
         when(voteRepository.findById(1L)).thenReturn(Optional.of(vote));
         when(spotRepository.findById(1L)).thenReturn(Optional.of(spot));
-        when(spotRepository.findAllByVoteId(1L)).thenReturn(spots);
+        when(spotRepository.findAllByVoteIdOrderBySequenceAsc(1L)).thenReturn(spots);
         when(spotRepository.save(any(Spot.class))).thenReturn(spot);
 
         assertDoesNotThrow(() -> {

--- a/src/test/java/org/example/flowday/domain/course/wish/controller/WishPlaceControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/wish/controller/WishPlaceControllerTest.java
@@ -3,8 +3,8 @@ package org.example.flowday.domain.course.wish.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.course.wish.dto.WishPlaceReqDTO;
-import org.example.flowday.domain.course.wish.dto.WishPlaceResDTO;
 import org.example.flowday.domain.member.entity.Member;
+import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.example.flowday.domain.course.wish.service.WishPlaceService;
@@ -43,14 +43,13 @@ class WishPlaceControllerTest {
     private Member partner;
     private WishPlaceReqDTO wishPlaceReqDTO;
     private WishPlaceReqDTO wishPlaceReqDTO2;
-    private WishPlaceResDTO wishPlaceResDTO;
-
     @BeforeAll
     void setUp() {
         member = Member.builder()
                 .name("tester")
                 .loginId("testId")
                 .pw("password")
+                .role(Role.ROLE_USER)
                 .build();
 
         memberRepository.save(member);
@@ -72,11 +71,10 @@ class WishPlaceControllerTest {
                         .placeId("ChIJgUbEo1")
                         .name("장소 이름1")
                         .city("서울")
-                        .sequence(1)
                         .build())
                 .build();
 
-        wishPlaceResDTO = wishPlaceService.updateSpotInWishPlace(member.getId(), wishPlaceReqDTO);
+        wishPlaceService.updateSpotInWishPlace(member.getId(), wishPlaceReqDTO);
 
         wishPlaceReqDTO2 = WishPlaceReqDTO.builder()
                 .memberId(partner.getId())
@@ -84,7 +82,6 @@ class WishPlaceControllerTest {
                         .placeId("ChIJgUbEo2")
                         .name("장소 이름2")
                         .city("대전")
-                        .sequence(1)
                         .build())
                 .build();
 
@@ -99,15 +96,14 @@ class WishPlaceControllerTest {
         mockMvc.perform(post("/api/v1/wishPlaces")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(wishPlaceReqDTO)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.memberId").value(member.getId()));
+                .andExpect(status().isNoContent());
     }
 
     @DisplayName("위시 플레이스 장소 삭제 테스트")
     @Test
     @WithUserDetails(value = "testId", userDetailsServiceBeanName = "securityUserService")
     void removeSpotFromWishPlace() throws Exception {
-        mockMvc.perform(delete("/api/v1/wishPlaces/member/{memberId}/spot/{spotId}", member.getId(), wishPlaceResDTO.getSpots().get(0).getId()))
+        mockMvc.perform(delete("/api/v1/wishPlaces/member/{memberId}/spot/{spotId}", member.getId(), 1L))
                 .andExpect(status().isNoContent());
     }
 

--- a/src/test/java/org/example/flowday/domain/course/wish/service/WishPlaceServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/course/wish/service/WishPlaceServiceTest.java
@@ -117,16 +117,13 @@ class WishPlaceServiceTest {
                         .placeId("ChIJgUbEo2")
                         .name("장소 이름2")
                         .city("서울")
-                        .sequence(2)
                         .build())
                 .build();
 
         when(wishPlaceRepository.findByMemberId(1L)).thenReturn(Optional.of(wishPlace));
 
-        WishPlaceResDTO result = wishPlaceService.updateSpotInWishPlace(member.getId(), wishPlaceReqDTO);
+        wishPlaceService.updateSpotInWishPlace(member.getId(), wishPlaceReqDTO);
 
-        // then
-        assertNotNull(result);
         verify(spotRepository, times(1)).save(any(Spot.class));
     }
 

--- a/src/test/java/org/example/flowday/domain/post/comment/comment/controller/ReplyControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/post/comment/comment/controller/ReplyControllerTest.java
@@ -81,7 +81,7 @@ public class ReplyControllerTest {
         // 테스트에 필요한 게시글 생성
         testPost = Post.builder()
                 .title("테스트 게시글")
-                .content("게시글 내용")
+                .contents("게시글 내용")
                 .writer(testMember)
                 .build();
         postRepository.save(testPost);
@@ -137,7 +137,7 @@ public class ReplyControllerTest {
         // 새로운 게시글 생성 (댓글 없음)
         Post newPost = Post.builder()
                 .title("새 게시글")
-                .content("새 게시글 내용")
+                .contents("새 게시글 내용")
                 .writer(testMember)
                 .build();
         postRepository.save(newPost);

--- a/src/test/java/org/example/flowday/domain/post/comment/comment/service/ReplyServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/post/comment/comment/service/ReplyServiceTest.java
@@ -55,7 +55,7 @@ class ReplyServiceTest {
 
         Post post = Post.builder()
                 .title("title")
-                .content("content")
+                .contents("content")
                 .build();
 
         postRepository.save(post);
@@ -89,7 +89,7 @@ class ReplyServiceTest {
 
         Post post = Post.builder()
                 .title("title")
-                .content("content")
+                .contents("content")
                 .build();
 
         postRepository.save(post);
@@ -133,7 +133,7 @@ class ReplyServiceTest {
 
         Post post = Post.builder()
                 .title("title")
-                .content("content")
+                .contents("content")
                 .build();
 
         postRepository.save(post);
@@ -176,7 +176,7 @@ class ReplyServiceTest {
 
         Post post = Post.builder()
                 .title("Test Post Title")
-                .content("Test Post Content")
+                .contents("Test Post Content")
                 .build();
         postRepository.save(post);
 

--- a/src/test/java/org/example/flowday/domain/post/comment/likecomment/controller/LikeReplyControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/post/comment/likecomment/controller/LikeReplyControllerTest.java
@@ -79,7 +79,7 @@ public class LikeReplyControllerTest {
         // 테스트에 필요한 게시글 생성
         testPost = Post.builder()
                 .title("테스트 게시글")
-                .content("게시글 내용")
+                .contents("게시글 내용")
                 .writer(testMember)
                 .build();
         postRepository.save(testPost);


### PR DESCRIPTION
## 🔓closed #38 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요. 이미지 or 움짤을 통해 확인 가능하도록 해주세요 -->
- 코스와 투표 api 기능을 수정하거나 추가 api를 구현했습니다.
- 해당 개발에 맞춰서 테스트 코드도 재작성했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 코스 수정 분리
    - 기본 상태 변경
    - 코스 안의 장소 순서 변경
    - 장소 1개 추가
    - 장소 1개 삭제
 
- 코스의 장소가 변경될 때마다 맞춰서 장소 순서 재넘버링
- 투표는 코스에 저장된 장소들로 생성되며, 선택된 장소 외의 장소들은 코스에서 삭제

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
-

## ✋ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 프론트에 맞춰서 수정을 진행했습니다. 혹시 변경사항이 있다면 반영하도록 하겠습니다!
