### PR TITLE
feat: S3 도입과 일부 API 수정

### DIFF
--- a/src/main/java/org/example/flowday/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/flowday/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.example.flowday.domain.member.dto.MemberDTO;
+import org.example.flowday.domain.member.exception.MemberException;
 import org.example.flowday.domain.member.exception.MemberTaskException;
 import org.example.flowday.domain.member.service.MemberService;
 import org.example.flowday.global.security.util.SecurityUser;
@@ -146,13 +147,34 @@ public class MemberController {
         return ResponseEntity.ok(memberService.deleteMember(user.getId()));
     }
 
+    // 기본 정보 설정
+    @PutMapping("/myInfo")
+    public ResponseEntity<Object> myInfo(
+            @AuthenticationPrincipal SecurityUser user,
+            MemberDTO.MyInfoSettingRequestDTO myinfo) {
+        try {
+            memberService.setMyinfo(user.getId(), myinfo);
+            return ResponseEntity.ok("Set MyInfo successful");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(MemberException.SET_MYINFO_FAILED.getMemberTaskException().getMessage());
+        }
+
+    }
+
     // 프로필 이미지 수정
     @Operation(summary = "프로필 이미지 수정")
     @PutMapping("/updateImage")
-    public ResponseEntity<MemberDTO.ChangeImageResponseDTO> modifyImage(
+    public ResponseEntity<Object> modifyImage(
             @AuthenticationPrincipal SecurityUser user,
             @RequestParam("image") MultipartFile image) {
-        return ResponseEntity.ok(memberService.changeProfileImage(user.getId(), image));
+        try {
+            memberService.changeProfileImage(user.getId(), image);
+            return ResponseEntity.ok("프로필 사진이 변경되었습니다");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(MemberException.MEMBER_IMAGE_NOT_MODIFIED.getMemberTaskException().getMessage());
+        }
     }
 
     // 생일 수정(등록)

--- a/src/main/java/org/example/flowday/domain/member/dto/MemberDTO.java
+++ b/src/main/java/org/example/flowday/domain/member/dto/MemberDTO.java
@@ -24,21 +24,12 @@ public class MemberDTO {
         private String email;
         @NotBlank(message = "비밀번호는 필수 입력 값 입니다")
         private String pw;
-        @NotBlank(message = "닉네임은 필수 입력 값 입니다")
-        private String name;
-        @NotBlank(message = "전화번호는 필수 입력 값 입니다") // 삭제 가능성
-        private String phoneNum;
-        @NotBlank(message = "생년월일은 필수 입력 값 입니다")
-        private LocalDate dateOfBirth;
 
         public Member toEntity() {
             return Member.builder()
                     .loginId(loginId)
                     .email(email)
                     .pw(pw)
-                    .name(name)
-                    .phoneNum(phoneNum)
-                    .birthDt(dateOfBirth)
                     .build();
         }
     }
@@ -50,7 +41,6 @@ public class MemberDTO {
         private String loginId;
         private String email;
         private String name;
-        private String phoneNum;
     }
 
     @Data
@@ -67,7 +57,6 @@ public class MemberDTO {
         private String email;
         private String pw;
         private String name;
-        private String phoneNum;
 
         public Member toEntity() {
             return Member.builder()
@@ -75,7 +64,6 @@ public class MemberDTO {
                     .email(email)
                     .pw(pw)
                     .name(name)
-                    .phoneNum(phoneNum)
                     .build();
         }
     }
@@ -97,7 +85,14 @@ public class MemberDTO {
         private String loginId;
         private String email;
         private String name;
-        private String phoneNum;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class MyInfoSettingRequestDTO {
+        private String name;
+        private MultipartFile file;
+        private LocalDate birthDt;
     }
 
     @Data
@@ -168,19 +163,12 @@ public class MemberDTO {
 
 
     @Data
+    @AllArgsConstructor
     public static class FindPartnerResponseDTO {
         private Long id;
         private String profileImage;
         private String name;
         private String email;
-        private String phoneNum;
 
-        public FindPartnerResponseDTO(Member member) {
-            this.id = member.getId();
-            this.name = member.getName();
-            this.email = member.getEmail();
-            this.phoneNum = member.getPhoneNum();
-            this.profileImage = member.getProfileImage();
-        }
     }
 }

--- a/src/main/java/org/example/flowday/domain/member/entity/Member.java
+++ b/src/main/java/org/example/flowday/domain/member/entity/Member.java
@@ -44,9 +44,7 @@ public class Member {
     private String email;
     @Column(unique = true)
     private String name;
-    private String phoneNum;
     private Long partnerId;
-    private String profileImage;
     private Long chattingRoomId;
 
     @Column(columnDefinition = "TEXT")
@@ -79,9 +77,6 @@ public class Member {
         if (!isValidEmail(member.email)) {
             throw MemberException.INVALID_EMAIL_FORMAT.getMemberTaskException();
         }
-        if (!isValidPhoneNumber(member.phoneNum)) {
-            throw MemberException.INVALID_PHONENUM_FORMAT.getMemberTaskException();
-        }
     }
 
     // 특수문자 필터링 메소드
@@ -96,10 +91,5 @@ public class Member {
     // 이메일 유효성 검사
     private boolean isValidEmail(String email) {
         return email != null && email.matches("^[A-Za-z0-9+_.-]+@(.+)$");
-    }
-
-    // 전화번호 유효성 검사 (예시: 숫자만 허용)
-    private boolean isValidPhoneNumber(String phoneNum) {
-        return phoneNum != null && phoneNum.matches("^[0-9]+$");
     }
 }

--- a/src/main/java/org/example/flowday/domain/member/exception/MemberException.java
+++ b/src/main/java/org/example/flowday/domain/member/exception/MemberException.java
@@ -12,7 +12,8 @@ public enum MemberException {
     INVALID_EMAIL_FORMAT("올바르지 않은 이메일 형식입니다.", HttpStatus.BAD_REQUEST),
     INVALID_PHONENUM_FORMAT("올바르지 않은 전화번호 형식입니다.", HttpStatus.BAD_REQUEST),
     INVALID_CHAR_FORMAT("올바르지 않은 문자열 형식입니다.", HttpStatus.BAD_REQUEST),
-    UPDATE_PASSWORD_FAILED("비밀번호 재설정에 실패했습니다", HttpStatus.BAD_REQUEST);
+    UPDATE_PASSWORD_FAILED("비밀번호 재설정에 실패했습니다", HttpStatus.BAD_REQUEST),
+    SET_MYINFO_FAILED("내 정보 설정에 실패했습니다", HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/src/main/java/org/example/flowday/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/flowday/domain/member/repository/MemberRepository.java
@@ -26,12 +26,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     void updateRefreshToken(@Param("loginId") String loginId, @Param("refreshToken") String refreshToken);
 
     @Query("SELECT " +
-            "m1.profileImage AS profileImage, " +
             "m1.name AS name, " +
-            "m2.profileImage AS partnerImage, " +
             "m2.name AS partnerName, " +
             "m1.relationshipDt AS relationshipDt, " +
-            "m1.birthDt AS birthDt " +
+            "m1.birthDt AS birthDt, " +
+            "m1.partnerId AS partnerId " +
             "FROM Member m1 " +
             "LEFT JOIN Member m2 ON m1.partnerId = m2.id " +
             "WHERE m1.id = :id")
@@ -43,7 +42,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m.id FROM Member m WHERE m.loginId = :loginId")
     Optional<Long> findIdByLoginId(String loginId);
 
-    @Query("SELECT m.id AS id, m.name AS name, m.email AS email, m.phoneNum AS num, m.profileImage AS image FROM Member m WHERE m.name = :name")
+    @Query("SELECT m.id AS id, m.name AS name, m.email AS email FROM Member m WHERE m.name = :name")
     Optional<Map<String, Object>> findByName(String name);
 
     @Query("SELECT m.loginId FROM Member m WHERE m.email=:email AND m.name=:name")


### PR DESCRIPTION
## 🔓closed #42 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요. 이미지 or 움짤을 통해 확인 가능하도록 해주세요 -->
- 프로필 사진을 서버가 아닌 S3에 저장하도록 변경했습니다
- 회원가입 시 로그인아이디, 비밀번호, 이메일 만을 요구합니다
- 추가적인 부분은 기본 정보 입력 API로 분리하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 기존의 디렉토리 생성, 파일 저장, 파일 경로를 db에 저장하던 로직을 S3를 사용하도록 변경했습니다.
- 회원가입 DTO가 변경되었습니다
- 기본정보 입력 API로 이제 소셜로그인 사용자에게도 정보를 입력할 수 있도록 하였습니다.


## ✋ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- DTO 와 Entity의 변경이 있습니다. 테스트코드나 멤버 생성시 주의하세요
