### PR TITLE
fix : 웹소켓 관련 CORS 에러 해결

### DIFF
--- a/src/main/java/org/example/flowday/global/security/config/WebConfig.java
+++ b/src/main/java/org/example/flowday/global/security/config/WebConfig.java
@@ -12,5 +12,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE");
+
+        registry.addMapping("/connect/websocket")
+                .allowedOrigins("*");
     }
 }


### PR DESCRIPTION
## 🔓closed #59

## 👩‍💻 요구 사항과 구현 내용 
- 웹소켓 경로는 api로 시작하지 않아 프론트 요청에 CORS 에러가 발생했습니다.
- 웹, 앱 테스트 기간 동안만 웹소켓 연결 경로에 모든 출처를 허용합니다.
