### PR TITLE
refactor : 채팅 조회 시 페이징 처리 간소화 및 @Transactional 어노테이션 추가

### DIFF
--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
@@ -47,7 +48,9 @@ public class ChatApiController {
     ) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "sendTime"));
         Page<ChatMessageEntity> messages = chatService.getPagedChatMessages(roomId, pageable);
-        Page<ChatResponse> chatResponses = messages.map(ChatResponse::from);
+        List<ChatResponse> chatResponses = messages.getContent().stream()
+                .map(message -> ChatResponse.from(message, messages.getNumber(), messages.getTotalPages()))
+                .toList();
         return ResponseEntity.ok(ApiResponse.success(chatResponses));
     }
 

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
@@ -34,6 +34,7 @@ public class ChatController {
 
         // TODO : 채팅 로그 저장 (동기 -> 비동기), 99L -> senderId
         chatService.saveMessage(roomId, 99L, responseMessage, time);
-        return new ChatResponse(99L, responseMessage, time);
+        // 페이지 정보는 웹소켓 연결에서는 의미 없으므로 0으로 설정
+        return new ChatResponse(99L, responseMessage, time, 0, 0);
     }
 }

--- a/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
@@ -6,13 +6,21 @@ import java.time.LocalDateTime;
 public record ChatResponse(
         Long senderId,
         String message,
-        LocalDateTime time
+        LocalDateTime time,
+        Integer pageNumber,  // 현재 페이지 번호
+        Integer totalPages   // 총 페이지 수
 ) {
-    public static ChatResponse from(final ChatMessageEntity chatMessageEntity) {
+    public static ChatResponse from(
+            final ChatMessageEntity chatMessageEntity,
+            Integer pageNumber,
+            Integer totalPages
+    ) {
         return new ChatResponse(
                 chatMessageEntity.getFromId(),
                 chatMessageEntity.getTextMessage(),
-                chatMessageEntity.getSendTime()
+                chatMessageEntity.getSendTime(),
+                pageNumber,
+                totalPages
         );
     }
 }

--- a/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
+++ b/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
@@ -8,9 +8,11 @@ import org.example.flowday.domain.chat.repository.ChatRoomRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
@@ -19,6 +21,7 @@ public class ChatService {
     /**
      * 채팅 방 생성
      */
+    @Transactional
     public Long registerChatRoom(final LocalDateTime time) {
         ChatRoomEntity chatRoom = ChatRoomEntity.create(time);
         ChatRoomEntity savedChatRoom = chatRoomRepository.save(chatRoom);
@@ -29,6 +32,7 @@ public class ChatService {
     /**
      * 채팅 메세지 저장
      */
+    @Transactional
     public void saveMessage(
             final Long roomId,
             final Long senderId,
@@ -57,6 +61,7 @@ public class ChatService {
     /**
      * 채팅 방 삭제
      */
+    @Transactional
     public Long deleteChatRoom(final Long roomId) {
         ChatRoomEntity chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));


### PR DESCRIPTION
## 🔓closed #51

## 📌 과제 설명 
- 프론트엔드 측에서 채팅 내역 조회 시 필요한 필드만 응답하도록 요청하였습니다.
- 서비스 단에 `@Transactional` 어노테이션 없었습니다.

## 👩‍💻 요구 사항과 구현 내용 
- 채팅 조회시 다른 page 요소를 삭제하고 '현재 페이지 번호, 총 페이지 수' 정보만 응답하도록 수정했습니다.
- 조회의 경우 변경 감지 작업을 생략하여 리소스를 절약하기 위해 `@Transactional(readOnly = true)`를 적용했습니다.