### PR TITLE
refactor : 중복으로 적용된 웹소켓 접근 경로 삭제

### DIFF
--- a/src/main/java/org/example/flowday/global/config/StompWebSocketConfig.java
+++ b/src/main/java/org/example/flowday/global/config/StompWebSocketConfig.java
@@ -23,6 +23,7 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/connect/websocket")
+                // TODO: 구체적인 경로로 수정
                 .setAllowedOriginPatterns("*");
     }
 }

--- a/src/main/java/org/example/flowday/global/security/config/WebConfig.java
+++ b/src/main/java/org/example/flowday/global/security/config/WebConfig.java
@@ -12,8 +12,5 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE");
-
-        registry.addMapping("/connect/websocket")
-                .allowedOrigins("*");
     }
 }


### PR DESCRIPTION
## 🔓closed #71

## 📌 과제 설명 
-  중복으로 적용된 웹소켓 접근 경로 중 하나를 삭제했습니다. 

## ✋ PR 포인트 
- 현재는 경로 전체를 열어두고 있지만, 보안상 정확한 경로로 수정이 필요합니다. 