### PR TITLE
refactor : SecurityContextHolder의 member 이용

### DIFF
--- a/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
+++ b/src/main/java/org/example/flowday/domain/course/course/controller/CourseController.java
@@ -26,7 +26,7 @@ public class CourseController {
     @Operation(summary = "생성")
     @PostMapping
     public ResponseEntity<CourseResDTO> createCourse(@RequestBody CourseReqDTO courseReqDTO, @AuthenticationPrincipal SecurityUser user) {
-        return ResponseEntity.ok(courseService.saveCourse(user.getId(), courseReqDTO));
+        return ResponseEntity.ok(courseService.saveCourse(user, courseReqDTO));
     }
 
     // 코스 조회
@@ -97,14 +97,14 @@ public class CourseController {
 
     // 회원 별 위시 플레이스, 코스 목록 조회
     @Operation(summary = "위시 플레이스 + 코스 목록 조회", description = "나와 (파트너의) 위시플레이스와 나와 (파트너의 COUPLE 상태) 코스 목록")
-    @GetMapping("/member/{memberId}")
+    @GetMapping
     public ResponseEntity<Page<Object>> CourseListByMember(
-            @PathVariable("memberId") Long memberId,
+            @AuthenticationPrincipal SecurityUser user,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size)
     {
         PageReqDTO pageReqDTO = PageReqDTO.builder().page(page).size(size).build();
-        return ResponseEntity.ok(courseService.findWishPlaceAndCourseListByMember(memberId, pageReqDTO));
+        return ResponseEntity.ok(courseService.findWishPlaceAndCourseListByMember(user, pageReqDTO));
     }
 
     // 그만 보기 시 상대방의 코스 비공개로 상태 변경
@@ -112,9 +112,9 @@ public class CourseController {
     @PatchMapping("/{courseId}/private")
     public ResponseEntity<Void> updateCourseStatusToPrivate(
             @PathVariable Long courseId,
-            @AuthenticationPrincipal SecurityUser member
+            @AuthenticationPrincipal SecurityUser user
     ) {
-        courseService.updateCourseStatusToPrivate(member.getId(), courseId);
+        courseService.updateCourseStatusToPrivate(user.getId(), courseId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
+++ b/src/main/java/org/example/flowday/domain/course/course/service/CourseService.java
@@ -19,6 +19,7 @@ import org.example.flowday.domain.course.wish.service.WishPlaceService;
 import org.example.flowday.domain.member.entity.Member;
 import org.example.flowday.domain.member.exception.MemberException;
 import org.example.flowday.domain.member.repository.MemberRepository;
+import org.example.flowday.global.security.util.SecurityUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -43,12 +44,9 @@ public class CourseService {
     private final WishPlaceService wishPlaceService;
 
     // 코스 생성
-    public CourseResDTO saveCourse(Long userId, CourseReqDTO courseReqDTO) {
-        Member member = memberRepository.findById(userId).orElseThrow(MemberException.MEMBER_NOT_FOUND::getMemberTaskException);
-
-        try {
+    public CourseResDTO saveCourse(SecurityUser user, CourseReqDTO courseReqDTO) {try {
             Course course = Course.builder()
-                    .member(member)
+                    .member(user.member())
                     .title(courseReqDTO.getTitle())
                     .status(courseReqDTO.getStatus())
                     .date(courseReqDTO.getDate())
@@ -178,11 +176,11 @@ public class CourseService {
     }
 
     // 회원 별 코스 목록 조회
-    public List<CourseResDTO> findCourseByMember(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberException.MEMBER_NOT_FOUND::getMemberTaskException);
+    public List<CourseResDTO> findCourseByMember(Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(MemberException.MEMBER_NOT_FOUND::getMemberTaskException);
         Long partnerId = member.getPartnerId() != null ? member.getPartnerId() : null;
 
-        List<Course> memberCourses = courseRepository.findAllByMemberId(memberId);
+        List<Course> memberCourses = courseRepository.findAllByMemberId(userId);
         List<Course> partnerCourses = partnerId != null
                 ? courseRepository.findAllByMemberIdAndStatus(partnerId, Status.COUPLE)
                 : new ArrayList<>();
@@ -207,11 +205,11 @@ public class CourseService {
     }
 
     // 회원 별 위시 플레이스, 코스 목록 조회
-    public Page<Object> findWishPlaceAndCourseListByMember(Long memberId, PageReqDTO pageReqDTO) {
+    public Page<Object> findWishPlaceAndCourseListByMember(SecurityUser user, PageReqDTO pageReqDTO) {
         Pageable pageable = pageReqDTO.getPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        List<WishPlaceResDTO> wishPlaceResDTOS = wishPlaceService.getMemberAndPartnerWishPlaces(memberId);
-        List<CourseResDTO> courseResDTOS = findCourseByMember(memberId);
+        List<WishPlaceResDTO> wishPlaceResDTOS = wishPlaceService.getMemberAndPartnerWishPlaces(user);
+        List<CourseResDTO> courseResDTOS = findCourseByMember(user.getId());
 
         List<Object> combinedCourses = new ArrayList<>();
         combinedCourses.addAll(wishPlaceResDTOS);
@@ -225,10 +223,10 @@ public class CourseService {
     }
 
     // 그만 보기 시 상대방의 코스 비공개로 상태 변경
-    public void updateCourseStatusToPrivate(Long memberId, Long courseId) {
+    public void updateCourseStatusToPrivate(Long userId, Long courseId) {
         Course course = courseRepository.findById(courseId).orElseThrow(CourseException.NOT_FOUND::get);
 
-        if (!memberId.equals(courseRepository.findById(courseId).get().getMember().getPartnerId())) {
+        if (!userId.equals(courseRepository.findById(courseId).get().getMember().getPartnerId())) {
             throw CourseException.FORBIDDEN.get();
         }
 
@@ -241,8 +239,8 @@ public class CourseService {
     }
 
     // 연인 관계 해지 시 모든 코스 비공개로 변경
-    public void updateCourseListStatusToPrivate(Long memberId) {
-        List<Course> courses = courseRepository.findAllByMemberId(memberId);
+    public void updateCourseListStatusToPrivate(Long userId) {
+        List<Course> courses = courseRepository.findAllByMemberId(userId);
 
         for (Course course : courses) {
             if (Status.COUPLE.equals(course.getStatus())) {

--- a/src/main/java/org/example/flowday/domain/course/wish/controller/WishPlaceController.java
+++ b/src/main/java/org/example/flowday/domain/course/wish/controller/WishPlaceController.java
@@ -36,21 +36,20 @@ public class WishPlaceController {
 
     // 위시 플레이스에서 장소 삭제
     @Operation(summary = "장소 삭제")
-    @DeleteMapping("/member/{memberId}/spot/{spotId}")
+    @DeleteMapping("/spot/{spotId}")
     public ResponseEntity<Void> removeSpotFromWishPlace(
-            @PathVariable Long memberId,
             @PathVariable Long spotId,
             @AuthenticationPrincipal SecurityUser user
     ) {
-        wishPlaceService.removeSpotFromWishPlace(user.getId(), memberId, spotId);
+        wishPlaceService.removeSpotFromWishPlace(user.getId(), spotId);
         return ResponseEntity.noContent().build();
     }
 
     // 회원 별 위시 플레이스 목록 조회
     @Operation(summary = "회원 별 위시 플레이스 목록 조회")
-    @GetMapping("/member/{memberId}")
-    public ResponseEntity<List<WishPlaceResDTO>> getMemberWishPlaces(@PathVariable Long memberId) {
-        List<WishPlaceResDTO> wishPlaces = wishPlaceService.getMemberWishPlaces(memberId);
+    @GetMapping
+    public ResponseEntity<List<WishPlaceResDTO>> getMemberWishPlaces(@AuthenticationPrincipal SecurityUser user) {
+        List<WishPlaceResDTO> wishPlaces = wishPlaceService.getMemberWishPlaces(user.getId());
         return ResponseEntity.ok(wishPlaces);
     }
 

--- a/src/test/java/org/example/flowday/domain/course/course/controller/CourseControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/course/controller/CourseControllerTest.java
@@ -10,6 +10,7 @@ import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.member.entity.Member;
 import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
+import org.example.flowday.global.security.util.SecurityUser;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -63,6 +64,7 @@ class CourseControllerTest {
                 .build();
 
         memberRepository.save(member);
+        SecurityUser securityUser = new SecurityUser(member);
 
         partner = Member.builder()
                 .name("partner")
@@ -73,6 +75,7 @@ class CourseControllerTest {
                 .build();
 
         memberRepository.save(partner);
+        SecurityUser securityUser2 = new SecurityUser(partner);
 
         courseReqDTO = CourseReqDTO.builder()
                 .title("코스 이름")
@@ -81,7 +84,7 @@ class CourseControllerTest {
                 .color("blue")
                 .build();
 
-        courseResDTO = courseService.saveCourse(member.getId(), courseReqDTO);
+        courseResDTO = courseService.saveCourse(securityUser, courseReqDTO);
 
         SpotReqDTO spotReqDTO1 = SpotReqDTO.builder()
                 .id(1L)
@@ -110,7 +113,7 @@ class CourseControllerTest {
                 .color("blue")
                 .build();
 
-        courseResDTO2 = courseService.saveCourse(partner.getId(), courseReqDTO2);
+        courseResDTO2 = courseService.saveCourse(securityUser2, courseReqDTO2);
     }
 
     @DisplayName("코스 생성 테스트")
@@ -218,7 +221,7 @@ class CourseControllerTest {
     void getCourseListByMember() throws Exception {
         PageReqDTO pageReqDTO = PageReqDTO.builder().page(1).size(10).build();
 
-        mockMvc.perform(get("/api/v1/courses/member/{memberId}", member.getId())
+        mockMvc.perform(get("/api/v1/courses", member.getId())
                         .param("page", "1")
                         .param("size", "10"))
                 .andExpect(status().isOk());

--- a/src/test/java/org/example/flowday/domain/course/course/service/CourseServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/course/course/service/CourseServiceTest.java
@@ -17,6 +17,7 @@ import org.example.flowday.domain.course.wish.service.WishPlaceService;
 import org.example.flowday.domain.member.entity.Member;
 import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
+import org.example.flowday.global.security.util.SecurityUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -188,8 +189,8 @@ class CourseServiceTest {
                 .build();
 
         when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-
-        CourseResDTO result = courseService.saveCourse(member.getId(), courseReqDTO);
+        SecurityUser securityUser = new SecurityUser(member);
+        CourseResDTO result = courseService.saveCourse(securityUser, courseReqDTO);
 
         assertThat(result).isNotNull();
         assertThat(result.getTitle()).isEqualTo("코스 이름");
@@ -349,7 +350,8 @@ class CourseServiceTest {
         );
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(wishPlaceService.getMemberAndPartnerWishPlaces(memberId)).thenReturn(wishPlaceResDTOList);
+        SecurityUser securityUser = new SecurityUser(member);
+        when(wishPlaceService.getMemberAndPartnerWishPlaces(securityUser)).thenReturn(wishPlaceResDTOList);
         when(courseService.findCourseByMember(memberId)).thenReturn(courseResDTOList);
 
         List<Object> combinedList = new ArrayList<>();

--- a/src/test/java/org/example/flowday/domain/course/spot/controller/SpotControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/spot/controller/SpotControllerTest.java
@@ -9,6 +9,7 @@ import org.example.flowday.domain.course.spot.dto.SpotReqDTO;
 import org.example.flowday.domain.member.entity.Member;
 import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
+import org.example.flowday.global.security.util.SecurityUser;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -66,6 +67,7 @@ class SpotControllerTest {
                 .build();
 
         memberRepository.save(member);
+        SecurityUser securityUser = new SecurityUser(member);
 
         courseReqDTO = CourseReqDTO.builder()
                 .title("코스 이름")
@@ -74,7 +76,7 @@ class SpotControllerTest {
                 .color("blue")
                 .build();
 
-        courseResDTO = courseService.saveCourse(member.getId(), courseReqDTO);
+        courseResDTO = courseService.saveCourse(securityUser, courseReqDTO);
 
         spotReqDTO1 = SpotReqDTO.builder()
                 .placeId("kasal")

--- a/src/test/java/org/example/flowday/domain/course/wish/controller/WishPlaceControllerTest.java
+++ b/src/test/java/org/example/flowday/domain/course/wish/controller/WishPlaceControllerTest.java
@@ -101,7 +101,7 @@ class WishPlaceControllerTest {
     @Test
     @WithUserDetails(value = "testId4", userDetailsServiceBeanName = "securityUserService")
     void removeSpotFromWishPlace() throws Exception {
-        mockMvc.perform(delete("/api/v1/wishPlaces/member/{memberId}/spot/{spotId}", member.getId(), wishPlaceService.getMemberWishPlaces(member.getId()).get(0).getSpots().get(0).getId()))
+        mockMvc.perform(delete("/api/v1/wishPlaces/spot/{spotId}", wishPlaceService.getMemberWishPlaces(member.getId()).get(0).getSpots().get(0).getId()))
                 .andExpect(status().isNoContent());
     }
 
@@ -109,7 +109,7 @@ class WishPlaceControllerTest {
     @Test
     @WithUserDetails(value = "testId4", userDetailsServiceBeanName = "securityUserService")
     void getMemberAndPartnerWishPlaces() throws Exception {
-        mockMvc.perform(get("/api/v1/wishPlaces/member/{memberId}", member.getId()))
+        mockMvc.perform(get("/api/v1/wishPlaces", member.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1));
     }

--- a/src/test/java/org/example/flowday/domain/course/wish/service/WishPlaceServiceTest.java
+++ b/src/test/java/org/example/flowday/domain/course/wish/service/WishPlaceServiceTest.java
@@ -10,6 +10,7 @@ import org.example.flowday.domain.course.wish.repository.WishPlaceRepository;
 import org.example.flowday.domain.member.entity.Member;
 import org.example.flowday.domain.member.entity.Role;
 import org.example.flowday.domain.member.repository.MemberRepository;
+import org.example.flowday.global.security.util.SecurityUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,8 @@ class WishPlaceServiceTest {
         when(wishPlaceRepository.findAllByMemberId(1L)).thenReturn(List.of(wishPlace));
         when(wishPlaceRepository.findAllByMemberId(2L)).thenReturn(List.of(wishPlace2));
 
-        List<WishPlaceResDTO> result = wishPlaceService.getMemberAndPartnerWishPlaces(1L);
+        SecurityUser securityUser = new SecurityUser(member);
+        List<WishPlaceResDTO> result = wishPlaceService.getMemberAndPartnerWishPlaces(securityUser);
 
         assertNotNull(result);
         assertThat(result).hasSize(2);


### PR DESCRIPTION
## 🔓closed #95 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요. 이미지 or 움짤을 통해 확인 가능하도록 해주세요 -->
- SecurityContextHolder의 member 이용
- 엔드포인트 memberId 제거
- 테스트 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- SecurityContextHolder의 member를 이용해 memberRepository.findById를 제거했습니다.
- 엔드포인트에 남아있던 memberId를 제거했습니다.
- 맞춰서 테스트 수정했습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- 재영님께서 SecurityContextHolder의 member를 이용할 수 있도록 알려주셔서 수정했습니다 :)


## ✋ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 빠른 배포를 위해 merge하는 점 양해부탁드립니다 ~
