### PR TITLE
refactor : RDBMS에서 NoSQL로 채팅 메세지 저장 및 조회 구조 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ flowday_dev.mv.db
 flowday_dev.trace.db
 /src/main/resources/application-secret.yml
 /src/main/resources/static
+db/mongodb/data

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     runtimeOnly 'com.h2database:h2'
+    // mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:6.0.3
+    container_name: mongodb_container
+    volumes:
+      - ./db/mongodb/data:/data/db
+    ports:
+      - "27017:27017"
+    networks:
+      - flowday
+    command: mongod --noauth
+
+networks:
+  flowday:

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatApiController.java
@@ -3,7 +3,7 @@ package org.example.flowday.domain.chat.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.flowday.domain.chat.common.ApiResponse;
 import org.example.flowday.domain.chat.dto.ChatResponse;
-import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.entity.ChatMessageDocument;
 import org.example.flowday.domain.chat.service.ChatService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,7 +38,7 @@ public class ChatApiController {
     }
 
     /**
-     * 채팅 조회 (최신 10개, page)
+     * [NoSQL] 채팅 조회 (최신 10개, page)
      */
     @GetMapping("/{roomId}")
     public ResponseEntity<ApiResponse> getPagedChatMessages(
@@ -47,9 +47,11 @@ public class ChatApiController {
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "sendTime"));
-        Page<ChatMessageEntity> messages = chatService.getPagedChatMessages(roomId, pageable);
+        Page<ChatMessageDocument> messages = chatService.getPagedChatMessages(roomId, pageable);
+
+        int pageNumber = messages.getNumber() + 1;
         List<ChatResponse> chatResponses = messages.getContent().stream()
-                .map(message -> ChatResponse.from(message, messages.getNumber(), messages.getTotalPages()))
+                .map(message -> ChatResponse.from(message, pageNumber, messages.getTotalPages()))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(chatResponses));
     }

--- a/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/org/example/flowday/domain/chat/dto/ChatResponse.java
@@ -1,6 +1,6 @@
 package org.example.flowday.domain.chat.dto;
 
-import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.entity.ChatMessageDocument;
 import java.time.LocalDateTime;
 
 public record ChatResponse(
@@ -11,14 +11,14 @@ public record ChatResponse(
         Integer totalPages   // 총 페이지 수
 ) {
     public static ChatResponse from(
-            final ChatMessageEntity chatMessageEntity,
+            final ChatMessageDocument chatMessageDocument,
             Integer pageNumber,
             Integer totalPages
     ) {
         return new ChatResponse(
-                chatMessageEntity.getFromId(),
-                chatMessageEntity.getTextMessage(),
-                chatMessageEntity.getSendTime(),
+                chatMessageDocument.getFromId(),
+                chatMessageDocument.getTextMessage(),
+                chatMessageDocument.getSendTime(),
                 pageNumber,
                 totalPages
         );

--- a/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageDocument.java
+++ b/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageDocument.java
@@ -1,0 +1,58 @@
+package org.example.flowday.domain.chat.entity;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Document(collection = ChatMessageDocument.COLLECTION_NAME)
+@CompoundIndexes({
+        @CompoundIndex(name = "chatRoomId_sendTime_idx", def = "{'chatRoomId': 1, 'sendTime': -1}")
+})
+public class ChatMessageDocument {
+    public static final String COLLECTION_NAME = "chat_messages";
+
+    @Id
+    private ObjectId id;
+    private Long chatRoomId;
+    private Long fromId;
+    private String textMessage;
+    private LocalDateTime sendTime;
+
+    @Builder
+    public ChatMessageDocument(
+            final ObjectId id,
+            final Long chatRoomId,
+            final Long fromId,
+            final String textMessage,
+            final LocalDateTime sendTime
+    ) {
+        this.id = id;
+        this.chatRoomId = chatRoomId;
+        this.fromId = fromId;
+        this.textMessage = textMessage;
+        this.sendTime = sendTime;
+    }
+
+    public static ChatMessageDocument create(
+            final Long chatRoomId,
+            final Long fromId,
+            final String textMessage,
+            final LocalDateTime sendTime
+    ) {
+        return ChatMessageDocument.builder()
+                .chatRoomId(chatRoomId)
+                .fromId(fromId)
+                .textMessage(textMessage)
+                .sendTime(sendTime)
+                .build();
+    }
+}

--- a/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageEntity.java
+++ b/src/main/java/org/example/flowday/domain/chat/entity/ChatMessageEntity.java
@@ -46,18 +46,4 @@ public class ChatMessageEntity {
         this.textMessage = textMessage;
         this.sendTime = sendTime;
     }
-
-    public static ChatMessageEntity create(
-            final Long chatRoomId,
-            final Long fromId,
-            final String textMessage,
-            final LocalDateTime sendTime
-    ) {
-        return ChatMessageEntity.builder()
-                .chatRoomId(chatRoomId)
-                .fromId(fromId)
-                .textMessage(textMessage)
-                .sendTime(sendTime)
-                .build();
-    }
 }

--- a/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageDocumentRepository.java
+++ b/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageDocumentRepository.java
@@ -1,0 +1,11 @@
+package org.example.flowday.domain.chat.repository;
+
+import org.bson.types.ObjectId;
+import org.example.flowday.domain.chat.entity.ChatMessageDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatMessageDocumentRepository extends MongoRepository<ChatMessageDocument, ObjectId> {
+    Page<ChatMessageDocument> findByChatRoomId(Long chatRoomId, Pageable pageable);
+}

--- a/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/example/flowday/domain/chat/repository/ChatMessageRepository.java
@@ -1,10 +1,7 @@
 package org.example.flowday.domain.chat.repository;
 
 import org.example.flowday.domain.chat.entity.ChatMessageEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
-    Page<ChatMessageEntity> findByChatRoomId(Long roomId, Pageable pageable);
 }

--- a/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
+++ b/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
@@ -1,9 +1,9 @@
 package org.example.flowday.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.entity.ChatMessageDocument;
 import org.example.flowday.domain.chat.entity.ChatRoomEntity;
-import org.example.flowday.domain.chat.repository.ChatMessageRepository;
+import org.example.flowday.domain.chat.repository.ChatMessageDocumentRepository;
 import org.example.flowday.domain.chat.repository.ChatRoomRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Transactional(readOnly = true)
 @Service
 public class ChatService {
-    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageDocumentRepository chatMessageDocumentRepository;
     private final ChatRoomRepository chatRoomRepository;
 
     /**
@@ -30,32 +30,31 @@ public class ChatService {
     }
 
     /**
-     * 채팅 메세지 저장
+     * [NoSQL] 채팅 메세지 저장
      */
-    @Transactional
-    public void saveMessage(
+    public ChatMessageDocument saveMessage(
             final Long roomId,
             final Long senderId,
             final String responseMessage,
             final LocalDateTime time
     ) {
-        ChatMessageEntity chatMessage = ChatMessageEntity.create(
+        ChatMessageDocument chatMessageDocument = ChatMessageDocument.create(
                 roomId,
                 senderId,
                 responseMessage,
                 time
         );
-        chatMessageRepository.save(chatMessage);
+        return chatMessageDocumentRepository.save(chatMessageDocument);
     }
 
     /**
-     * 채팅 조회
+     * [NoSQL] 채팅 메세지 조회
      */
-    public Page<ChatMessageEntity> getPagedChatMessages(
+    public Page<ChatMessageDocument> getPagedChatMessages(
             final Long roomId,
             final Pageable pageable
     ) {
-        return chatMessageRepository.findByChatRoomId(roomId, pageable);
+        return chatMessageDocumentRepository.findByChatRoomId(roomId, pageable);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/flowday_chat_db
+      auto-index-creation: true
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 🔓closed #84

## 📌 과제 설명 
- 채팅 메시지 저장/조회 RDBMS → NoSQL(MongoDB) 전환

## 👩‍💻 요구 사항과 구현 내용 
- 전환 이유: 1:1 채팅의 읽기:쓰기 비율(1:1)고려 및 데이터 접근 지연시간이 낮기에 선택했습니다.
- 메시지 ID 설계: 채팅 세션 내 유일성을 보장하기 위해 chatRoomId_sendTime 복합키를 사용했습니다.