### PR TITLE
refactor : 채팅 메시지 저장을 비동기를 적용해 로직 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ flowday_dev.mv.db
 flowday_dev.trace.db
 /src/main/resources/application-secret.yml
 /src/main/resources/static
+db/mongodb/data

--- a/src/main/java/org/example/flowday/FlowdayApplication.java
+++ b/src/main/java/org/example/flowday/FlowdayApplication.java
@@ -3,8 +3,10 @@ package org.example.flowday;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 
+@EnableAsync
 @EnableWebSocket
 @SpringBootApplication
 @EnableJpaAuditing

--- a/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/flowday/domain/chat/controller/ChatController.java
@@ -32,7 +32,6 @@ public class ChatController {
         LocalDateTime time = LocalDateTime.now();
         String responseMessage = HtmlUtils.htmlEscape(chatMessage.message());
 
-        // TODO : 채팅 로그 저장 (동기 -> 비동기)
         chatService.saveMessage(roomId, senderId, responseMessage, time);
         // 페이지 정보는 웹소켓 연결에서는 의미 없으므로 0으로 설정
         return new ChatResponse(senderId, responseMessage, time, 0, 0);

--- a/src/main/java/org/example/flowday/domain/chat/event/ChatMessageEventHandler.java
+++ b/src/main/java/org/example/flowday/domain/chat/event/ChatMessageEventHandler.java
@@ -1,0 +1,33 @@
+package org.example.flowday.domain.chat.event;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.chat.entity.ChatMessageDocument;
+import org.example.flowday.domain.chat.event.dto.ChatMessageEvent;
+import org.example.flowday.domain.chat.repository.ChatMessageDocumentRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageEventHandler {
+    private final ChatMessageDocumentRepository chatMessageDocumentRepository;
+
+    @Async
+    @TransactionalEventListener
+    public void handle(ChatMessageEvent event) {
+        Long roomId = event.roomId();
+        Long senderId = event.senderId();
+        String responseMessage = event.responseMessage();
+        LocalDateTime time = event.time();
+
+        ChatMessageDocument chatMessageDocument = ChatMessageDocument.create(
+                roomId,
+                senderId,
+                responseMessage,
+                time
+        );
+        chatMessageDocumentRepository.save(chatMessageDocument);
+    }
+}

--- a/src/main/java/org/example/flowday/domain/chat/event/ChatMessageEventHandler.java
+++ b/src/main/java/org/example/flowday/domain/chat/event/ChatMessageEventHandler.java
@@ -1,0 +1,27 @@
+package org.example.flowday.domain.chat.event;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flowday.domain.chat.entity.ChatMessageEntity;
+import org.example.flowday.domain.chat.event.dto.ChatMessageEvent;
+import org.example.flowday.domain.chat.repository.ChatMessageRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageEventHandler {
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Async
+    @TransactionalEventListener
+    public void handle(ChatMessageEvent event) {
+        ChatMessageEntity chatMessage = ChatMessageEntity.create(
+                event.roomId(),
+                event.senderId(),
+                event.responseMessage(),
+                event.time()
+        );
+        chatMessageRepository.save(chatMessage);
+    }
+}

--- a/src/main/java/org/example/flowday/domain/chat/event/dto/ChatMessageEvent.java
+++ b/src/main/java/org/example/flowday/domain/chat/event/dto/ChatMessageEvent.java
@@ -1,0 +1,11 @@
+package org.example.flowday.domain.chat.event.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageEvent(
+        Long roomId,
+        Long senderId,
+        String responseMessage,
+        LocalDateTime time
+) {
+}

--- a/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
+++ b/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
@@ -3,8 +3,10 @@ package org.example.flowday.domain.chat.service;
 import lombok.RequiredArgsConstructor;
 import org.example.flowday.domain.chat.entity.ChatMessageDocument;
 import org.example.flowday.domain.chat.entity.ChatRoomEntity;
+import org.example.flowday.domain.chat.event.dto.ChatMessageEvent;
 import org.example.flowday.domain.chat.repository.ChatMessageDocumentRepository;
 import org.example.flowday.domain.chat.repository.ChatRoomRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 public class ChatService {
     private final ChatMessageDocumentRepository chatMessageDocumentRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 채팅 방 생성
@@ -30,21 +33,17 @@ public class ChatService {
     }
 
     /**
-     * [NoSQL] 채팅 메세지 저장
+     * [비동기 - 스프링 이벤트] 채팅 메세지 저장
      */
-    public ChatMessageDocument saveMessage(
+    public void saveMessage(
             final Long roomId,
             final Long senderId,
             final String responseMessage,
             final LocalDateTime time
     ) {
-        ChatMessageDocument chatMessageDocument = ChatMessageDocument.create(
-                roomId,
-                senderId,
-                responseMessage,
-                time
+        applicationEventPublisher.publishEvent(
+                new ChatMessageEvent(roomId, senderId, responseMessage, time)
         );
-        return chatMessageDocumentRepository.save(chatMessageDocument);
     }
 
     /**

--- a/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
+++ b/src/main/java/org/example/flowday/domain/chat/service/ChatService.java
@@ -3,8 +3,10 @@ package org.example.flowday.domain.chat.service;
 import lombok.RequiredArgsConstructor;
 import org.example.flowday.domain.chat.entity.ChatMessageEntity;
 import org.example.flowday.domain.chat.entity.ChatRoomEntity;
+import org.example.flowday.domain.chat.event.dto.ChatMessageEvent;
 import org.example.flowday.domain.chat.repository.ChatMessageRepository;
 import org.example.flowday.domain.chat.repository.ChatRoomRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 채팅 방 생성
@@ -30,22 +33,17 @@ public class ChatService {
     }
 
     /**
-     * 채팅 메세지 저장
+     * [비동기 - 스프링 이벤트] 채팅 메세지 저장
      */
-    @Transactional
     public void saveMessage(
             final Long roomId,
             final Long senderId,
             final String responseMessage,
             final LocalDateTime time
     ) {
-        ChatMessageEntity chatMessage = ChatMessageEntity.create(
-                roomId,
-                senderId,
-                responseMessage,
-                time
+        applicationEventPublisher.publishEvent(
+                new ChatMessageEvent(roomId, senderId, responseMessage, time)
         );
-        chatMessageRepository.save(chatMessage);
     }
 
     /**


### PR DESCRIPTION
## 🔓closed #78

## 📌 과제 설명 
- 웹소켓을 통해 채팅 메시지를 받을 때마다 동기적으로 데이터베이스에 저장하던 부분을 비동기로 개선했습니다.

## 👩‍💻 요구 사항과 구현 내용
- 스프링 이벤트를 활용하여 비동기 처리 기능을 구현했습니다.
- 비동기 동작 검증은 Thread.sleep()을 메서드 내에 사용해 진행했습니다.
- 성능 테스트는 H2 대신 MySQL을 사용해 진행했습니다.
  - H2는 메모리 기반이라 정확성이 떨어질 수 있어, 로컬 환경에서 MySQL을 적용해 테스트를 진행했습니다. (이 부분은 PR에 포함하지 않았습니다.)
  
## ✅ 성능 테스트
### MySQL 메세지 저장(동기)
![image](https://github.com/user-attachments/assets/ca32cb2a-d63c-4aa8-8cb4-794df5983aa2)
- 요청의 99%는 211ms이하의 응답 시간을 기록했습니다. 

### 스프링 이벤트 메세지 저장(비동기)
![image](https://github.com/user-attachments/assets/d4dab1e7-9181-4c98-b537-d530d883a3f3)
- 요청의 99%는 75ms이하의 응답 시간을 기록했습니다. 

### 🥳 성능 개선
스프링 이벤트 메시지 저장(비동기)은 MySQL 메시지 저장(동기) 대비 99%의 요청에서 응답 시간이 136ms (약 64%) 개선되었습니다.